### PR TITLE
Error message when setting commiter not registered

### DIFF
--- a/e2e/test_setcommitter.py
+++ b/e2e/test_setcommitter.py
@@ -84,3 +84,11 @@ class TestGuetSet(E2ETest):
 
         self.assertEqual('{} <{}>\n'.format(name, email), content[0])
         self.assertEqual('{} <{}>\n'.format(name, email), content[1])
+
+    def test_set_gracefully_displays_error_message_when_setting_committer_with_unknown_initials(self):
+        process = subprocess.Popen(['guet', 'init'])
+        process.wait()
+        process = subprocess.Popen(['guet', 'set', 'ui'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        full_output = process.communicate()
+        output = full_output[0].decode('utf-8')
+        self.assertEqual("No committer exists with initials 'ui'\n", output)

--- a/guet/commands/setcommitters.py
+++ b/guet/commands/setcommitters.py
@@ -26,25 +26,33 @@ class SetCommittersCommand(Command):
                  user_gateway: UserGateway = UserGateway(),
                  file_gateway: FileGateway = FileGateway(),
                  pair_set_gateway: PairSetGateway = PairSetGateway(),
-                 pair_set_committers_gateway: PairSetGatewayCommitterGateway = PairSetGatewayCommitterGateway()):
+                 pair_set_committers_gateway: PairSetGatewayCommitterGateway = PairSetGatewayCommitterGateway(),
+                 print_gateway: PrintGateway = PrintGateway()):
         super().__init__(args)
         self._pair_set_committers_gateway = pair_set_committers_gateway
         self._pair_set_gateway = pair_set_gateway
         self._user_gateway = user_gateway
         self._file_gateway = file_gateway
+        self._print_gateway = print_gateway
 
     def execute(self):
         committer_initials = self._args[1:]
         committers = []
+        should_set_committers = True
         pair_set_id = self._pair_set_gateway.add_pair_set(round(datetime.datetime.utcnow().timestamp()*1000))
         for committer_initial in committer_initials:
             committer = self._user_gateway.get_user(committer_initial)
+            if committer is None:
+                self._print_gateway.print("No committer exists with initials '{}'".format(committer_initial))
+                should_set_committers = False
+                break
             committers.append(CommitterInput(name=committer.name, email=committer.email))
             self._pair_set_committers_gateway.add_pair_set_committer(committer_initial, pair_set_id)
-        author = self._user_gateway.get_user(committer_initials[0])
-        self._file_gateway.set_committers(committers)
-        self._file_gateway.set_author_email(author.email)
-        self._file_gateway.set_author_name(author.name)
+        if should_set_committers:
+            author = self._user_gateway.get_user(committer_initials[0])
+            self._file_gateway.set_committers(committers)
+            self._file_gateway.set_author_email(author.email)
+            self._file_gateway.set_author_name(author.name)
 
     def help(self):
         pass


### PR DESCRIPTION
## Overview
When setting a committer, if the given initials aren't in the system, notify the user.

Connects #7 

### Demo
```
guet init
guet set nonsense
No committer exists with initials 'nonsense'
```

## Testing Instructions
Initialize guet, then attempt to set committers using initials that aren't registered.