### PR TITLE
Manage situations where there are already hooks

### DIFF
--- a/e2e/test_addcommitter.py
+++ b/e2e/test_addcommitter.py
@@ -18,7 +18,7 @@ import subprocess
 
 from e2e.e2etest import E2ETest
 from guet.commands.addcommitter import AddUserCommand
-from guet.gateway import UserGateway
+from guet.gateways.gateway import UserGateway
 
 
 class TestAddUser(E2ETest):

--- a/e2e/test_commit_depends_on_last_pair_set.py
+++ b/e2e/test_commit_depends_on_last_pair_set.py
@@ -5,7 +5,7 @@ from os.path import join, expanduser, isdir
 from shutil import rmtree
 
 from e2e.e2etest import E2ETest
-from guet.gateway import PairSetGateway
+from guet.gateways.gateway import PairSetGateway
 
 
 class TestGuetCommitRotatesAuthor(E2ETest):

--- a/e2e/test_setcommitter.py
+++ b/e2e/test_setcommitter.py
@@ -19,7 +19,7 @@ from os.path import join, expanduser
 
 from e2e.e2etest import E2ETest
 from guet import constants as const
-from guet.gateway import PairSetGatewayCommitterGateway
+from guet.gateways.gateway import PairSetGatewayCommitterGateway
 
 
 class TestGuetSet(E2ETest):
@@ -57,11 +57,11 @@ class TestGuetSet(E2ETest):
 
         with open(join(expanduser('~'), const.APP_FOLDER_NAME, const.AUTHOR_EMAIL)) as auther_email:
             content = auther_email.readline()
-        self.assertEquals(email, content)
+        self.assertEqual(email, content)
 
         with open(join(expanduser('~'), const.APP_FOLDER_NAME, const.AUTHOR_NAME)) as auther_name:
             content = auther_name.readline()
-        self.assertEquals(name, content)
+        self.assertEqual(name, content)
 
     def test_set_adds_multiple_users_to_committers_file(self):
         process = subprocess.Popen(['guet', 'init'])

--- a/e2e/test_setcommitter.py
+++ b/e2e/test_setcommitter.py
@@ -84,3 +84,11 @@ class TestGuetSet(E2ETest):
 
         self.assertEqual('{} <{}>\n'.format(name, email), content[0])
         self.assertEqual('{} <{}>\n'.format(name, email), content[1])
+
+    def test_set_gracefully_displays_error_message_when_setting_committer_with_unknown_initials(self):
+        process = subprocess.Popen(['guet', 'init'])
+        process.wait()
+        process = subprocess.Popen(['guet', 'set', 'ui'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        full_output = process.communicate()
+        output = full_output[0].decode('utf-8')
+        self.assertEqual("No committer exists with initials 'ui'\n", output)

--- a/guet/commands/addcommitter.py
+++ b/guet/commands/addcommitter.py
@@ -13,9 +13,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-
+from guet.gateways.io import PrintGateway
 from .command import Command
-from ..gateway import *
+from guet.gateways.gateway import *
 
 
 class AddUserCommand(Command):

--- a/guet/commands/command.py
+++ b/guet/commands/command.py
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from guet.gateway import *
+from guet.gateways.io import PrintGateway
 
 
 class Command:

--- a/guet/commands/help.py
+++ b/guet/commands/help.py
@@ -13,9 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-
+from guet.gateways.io import PrintGateway
 from .command import Command
-from ..gateway import *
 from ..util import get_command_subclasses
 
 

--- a/guet/commands/init.py
+++ b/guet/commands/init.py
@@ -13,9 +13,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-
+from guet.gateways.io import PrintGateway
 from .command import Command
-from ..gateway import *
+from guet.gateways.gateway import *
 
 
 class InitDataSourceCommand(Command):

--- a/guet/commands/setcommitters.py
+++ b/guet/commands/setcommitters.py
@@ -26,25 +26,33 @@ class SetCommittersCommand(Command):
                  user_gateway: UserGateway = UserGateway(),
                  file_gateway: FileGateway = FileGateway(),
                  pair_set_gateway: PairSetGateway = PairSetGateway(),
-                 pair_set_committers_gateway: PairSetGatewayCommitterGateway = PairSetGatewayCommitterGateway()):
+                 pair_set_committers_gateway: PairSetGatewayCommitterGateway = PairSetGatewayCommitterGateway(),
+                 print_gateway: PrintGateway = PrintGateway()):
         super().__init__(args)
         self._pair_set_committers_gateway = pair_set_committers_gateway
         self._pair_set_gateway = pair_set_gateway
         self._user_gateway = user_gateway
         self._file_gateway = file_gateway
+        self._print_gateway = print_gateway
 
     def execute(self):
         committer_initials = self._args[1:]
         committers = []
+        should_set_committers = True
         pair_set_id = self._pair_set_gateway.add_pair_set(round(datetime.datetime.utcnow().timestamp()*1000))
         for committer_initial in committer_initials:
             committer = self._user_gateway.get_user(committer_initial)
+            if committer is None:
+                self._print_gateway.print("No committer exists with initials '{}'".format(committer_initial))
+                should_set_committers = False
+                break
             committers.append(CommitterInput(name=committer.name, email=committer.email))
             self._pair_set_committers_gateway.add_pair_set_committer(committer_initial, pair_set_id)
-        author = self._user_gateway.get_user(committer_initials[0])
-        self._file_gateway.set_committers(committers)
-        self._file_gateway.set_author_email(author.email)
-        self._file_gateway.set_author_name(author.name)
+        if should_set_committers:
+            author = self._user_gateway.get_user(committer_initials[0])
+            self._file_gateway.set_committers(committers)
+            self._file_gateway.set_author_email(author.email)
+            self._file_gateway.set_author_name(author.name)
 
     def help(self):
         pass

--- a/guet/commands/setcommitters.py
+++ b/guet/commands/setcommitters.py
@@ -13,9 +13,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-
+from guet.gateways.io import PrintGateway
 from .command import Command
-from ..gateway import *
+from guet.gateways.gateway import *
 
 
 class SetCommittersCommand(Command):

--- a/guet/commit.py
+++ b/guet/commit.py
@@ -1,6 +1,7 @@
 import datetime
 
-from guet.gateway import FileGateway, PairSetGateway, PrintGateway
+from guet.gateways.gateway import FileGateway, PairSetGateway
+from guet.gateways.io import PrintGateway
 
 
 class PostCommitManager:

--- a/guet/gateways/io.py
+++ b/guet/gateways/io.py
@@ -1,0 +1,24 @@
+import builtins
+import sys
+
+from guet.stdout_manager import StdoutManager
+
+
+class InputGateway:
+
+    def __init__(self, input_method=builtins.input):
+        self._input_method = input_method
+
+    def input(self):
+        return self._input_method()
+
+
+class PrintGateway:
+    def __init__(self, stdout_manager=StdoutManager.get_instance()):
+        self._stdout_manager = stdout_manager
+
+    def print(self, text):
+        original_stdout = sys.stdout
+        sys.stdout = self._stdout_manager.get_stdout()
+        print(text)
+        sys.stdout = original_stdout

--- a/guet/stdin_manager.py
+++ b/guet/stdin_manager.py
@@ -1,0 +1,23 @@
+
+
+class StdinManager:
+
+    _instance = None
+
+    def __init__(self):
+        if StdinManager._instance is None:
+            StdinManager._instance = self
+            import sys
+            self._stdin = sys.__stdin__
+
+    @classmethod
+    def get_instance(cls):
+        if cls._instance is None:
+            StdinManager()
+        return cls._instance
+
+    def get_stdin(self):
+        return self._stdin
+
+    def set_stdin(self, stdin):
+        self._stdin = stdin

--- a/guet/stdout_manager.py
+++ b/guet/stdout_manager.py
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+
 class StdoutManager:
 
     _instance = None

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ setup(
         ]
     },
     packages=[
-      'guet',
-      'guet.commands'
+        'guet',
+        'guet.commands',
+        'guet.gateways'
     ]
 )

--- a/test/commands/test_addcommitter.py
+++ b/test/commands/test_addcommitter.py
@@ -17,7 +17,8 @@ limitations under the License.
 from unittest.mock import Mock, call
 
 from guet.commands.addcommitter import AddUserCommand
-from guet.gateway import *
+from guet.gateways.gateway import *
+from guet.gateways.io import PrintGateway
 from test.commands.test_command import CommandTest, create_test_case
 
 

--- a/test/commands/test_help.py
+++ b/test/commands/test_help.py
@@ -18,7 +18,7 @@ from unittest.mock import Mock
 
 from guet.commands.command import Command
 from guet.commands.help import HelpCommand
-from guet.gateway import *
+from guet.gateways.io import PrintGateway
 from test.commands.test_command import CommandTest, create_test_case
 
 

--- a/test/commands/test_init.py
+++ b/test/commands/test_init.py
@@ -17,7 +17,8 @@ limitations under the License.
 from unittest.mock import Mock
 
 from guet.commands.init import InitDataSourceCommand
-from guet.gateway import *
+from guet.gateways.gateway import *
+from guet.gateways.io import PrintGateway
 from test.commands.test_command import CommandTest, create_test_case
 
 

--- a/test/commands/test_setcommitters.py
+++ b/test/commands/test_setcommitters.py
@@ -1,8 +1,8 @@
-import datetime
 from unittest.mock import Mock
 
 from guet.commands.setcommitters import SetCommittersCommand
-from guet.gateway import *
+from guet.gateways.gateway import *
+from guet.gateways.io import PrintGateway
 from test.commands.test_command import CommandTest, create_test_case
 
 

--- a/test/commands/test_start.py
+++ b/test/commands/test_start.py
@@ -2,11 +2,26 @@
 from unittest.mock import Mock
 
 from guet.commands.start import StartCommand
-from guet.gateway import *
+from guet.gateways.gateway import *
 from test.commands.test_command import CommandTest, create_test_case
+from guet.gateways.io import PrintGateway, InputGateway
 
 
 class TestStartCommand(CommandTest):
+
+    def setUp(self):
+        self.mock_git_gateway = GitGateway()
+        self.mock_git_gateway.add_hooks = Mock()
+        self.mock_git_gateway.commit_msg_hook_exists = Mock()
+        self.mock_git_gateway.git_present = Mock()
+        self.mock_git_gateway.hook_present = Mock()
+        self.mock_git_gateway.any_hook_present = Mock()
+
+        self.mock_print_gateway = PrintGateway()
+        self.mock_print_gateway.print = Mock()
+
+        self.mock_input_gateway = InputGateway()
+        self.mock_input_gateway.input = Mock()
 
     def test_validate(self):
         cases = [
@@ -28,5 +43,22 @@ class TestStartCommand(CommandTest):
 
         mock_git_gateway.add_hooks.assert_called_once()
 
+    def test_execute_prompts_user_for_input_when_hooks_already_exist(self):
+        self.mock_git_gateway.git_present = Mock(return_value=True)
+        self.mock_git_gateway.any_hook_present = Mock(return_value=True)
+        self.mock_input_gateway.input = Mock(return_value='x')
+
+        command = self._create_command([])
+        command.execute()
+
+        self.mock_print_gateway.print.assert_called_once_with('There is already commit hooks in this project. Would you like to overwrite (o), create (c) the file and put it in the hooks folder, or cancel (x)?')
+        self.mock_input_gateway.input.assert_called_once()
+
     def test_get_short_help_message(self):
         self.assertEqual('Start guet usage in the repository at current directory', StartCommand.get_short_help_message())
+
+    def _create_command(self, args: list, git_gateway: GitGateway = None, print_gateway: PrintGateway = None, input_gateway: InputGateway = None):
+        gg = git_gateway if None else self.mock_git_gateway
+        pg = print_gateway if None else self.mock_print_gateway
+        ig = input_gateway if None else self.mock_input_gateway
+        return StartCommand(args, gg, pg, ig)

--- a/test/gateways/test_io.py
+++ b/test/gateways/test_io.py
@@ -1,0 +1,43 @@
+
+from io import StringIO
+import builtins
+import sys
+import unittest
+from guet.gateways.io import PrintGateway, InputGateway
+from guet.stdout_manager import StdoutManager
+from unittest.mock import Mock
+
+
+class TestPrintGateway(unittest.TestCase):
+
+    def setUp(self):
+        self.original_stdout = sys.stdout
+
+    def tearDown(self):
+        sys.stdout = self.original_stdout
+
+    def test_init_set_the_stdout_as_the_default_system_stdout(self):
+        print_gateway = PrintGateway()
+        self.assertEqual(StdoutManager.get_instance(), print_gateway._stdout_manager)
+
+    def test_print_writes_to_stdout(self):
+        stdout = StringIO()
+        stdout_manager = StdoutManager.get_instance()
+        stdout_manager.set_stdout(stdout)
+        print_gateway = PrintGateway(stdout_manager)
+        text = 'text'
+        print_gateway.print(text)
+        self.assertEqual(text + '\n', stdout.getvalue())
+
+
+class TestInputGateway(unittest.TestCase):
+
+    def test_input_gets_input_from_stdin(self):
+        mock = Mock(return_value='text')
+        input_gateway = InputGateway(mock)
+        input = input_gateway.input()
+        self.assertEqual('text', input)
+
+    def test_input_method_defaults_to_builtin_print(self):
+        input_gateway = InputGateway()
+        input_gateway._input_method = builtins.input

--- a/test/test_commit.py
+++ b/test/test_commit.py
@@ -5,7 +5,8 @@ import unittest
 from unittest.mock import Mock
 
 from guet.commit import PostCommitManager, PreCommitManager
-from guet.gateway import FileGateway, committer_result, PairSetGateway, pair_set_result, PrintGateway
+from guet.gateways.gateway import FileGateway, committer_result, PairSetGateway, pair_set_result
+from guet.gateways.io import PrintGateway
 
 
 class PostCommitManagerTest(unittest.TestCase):

--- a/test/test_stdin_manager.py
+++ b/test/test_stdin_manager.py
@@ -1,0 +1,25 @@
+
+import sys
+import unittest
+from guet.stdin_manager import StdinManager
+
+
+class TestStdinManager(unittest.TestCase):
+
+    def setUp(self):
+        StdinManager._instance = None
+
+    def test_init_sets_singleton_instance(self):
+        self.assertIsNone(StdinManager._instance)
+        stdin_manager = StdinManager()
+        self.assertEqual(StdinManager._instance, stdin_manager)
+
+    def test_init_sets_the_stdin_to_the_system_default(self):
+        self.assertEqual(sys.__stdin__, StdinManager.get_instance().get_stdin())
+
+    def test_set_stdin_sets_stdin(self):
+        stdin_manager = StdinManager.get_instance()
+        stdin = object()
+        stdin_manager.set_stdin(stdin)
+        self.assertEqual(stdin, stdin_manager.get_stdin())
+


### PR DESCRIPTION
## Overview
Brief description of what this PR does, and why it is needed.

Connects #1 

### Demo
In a project where you already have commit hooks, if you type `guet start`, you see
```
There is already commit hooks in this project. Would you like to overwrite (o), create (c) the file and put it in the hooks folder, or cancel (x)?
```

## Testing Instructions
Initialize repository with a pre-commit hook, and attempt to start guet in the folder to get the prompt
```
git init
touch .git/hooks/pre-commit
guet init
guet start
There is already commit hooks in this project. Would you like to overwrite (o), create (c) the file and put it in the hooks folder, or cancel (x)?
```
If you answer with `o`, then check `pre-commit`, `commit-msg`, and `post-commit` to see if they're full as expected.

If you answer `c`, then check `guet-pre-commit`, `guet-commit-msg`, and `guet-post-commit` to see if they're full as expected.

If you answer `x`, then there shouldn't be any new files.