### PR TITLE
Ignore case of committer initials on set/add committers

### DIFF
--- a/guet/commands/addcommitter.py
+++ b/guet/commands/addcommitter.py
@@ -38,7 +38,7 @@ class AddUserCommand(Command):
                 print('')
         else:
             try:
-                self._user_gateway.add_user(self._args[1], self._args[2], self._args[3])
+                self._user_gateway.add_user(str(self._args[1]).lower(), self._args[2], self._args[3])
             except UninitializedError:
                 print('guet has not been initialized yet! Please do so by running the command "guet init".')
 

--- a/guet/commands/setcommitters.py
+++ b/guet/commands/setcommitters.py
@@ -45,10 +45,10 @@ class SetCommittersCommand(Command):
 
     def _commit_pair_set_committers(self, committer_initials, committers, pair_set_committer_add, pair_set_id):
             for pair_set_committer in pair_set_committer_add:
-                initials = pair_set_committer
+                initials = str(pair_set_committer).lower()
                 id = pair_set_id
                 self._pair_set_committers_gateway.add_pair_set_committer(initials, id)
-            author = self._user_gateway.get_user(committer_initials[0])
+            author = self._user_gateway.get_user(str(committer_initials[0]).lower())
             actual_committers = [Committer(c.name, c.email) for c in committers]
             set_committers(actual_committers)
             set_committer_as_author(actual_committers[0])
@@ -56,7 +56,7 @@ class SetCommittersCommand(Command):
     def _prepare_pair_set_committers(self, committer_initials: list, committers: list, pair_set_committer_add: list):
         should_set_committers = True
         for committer_initial in committer_initials:
-            committer = self._user_gateway.get_user(committer_initial)
+            committer = self._user_gateway.get_user(str(committer_initial).lower())
             if committer is None:
                 print("No committer exists with initials '{}'".format(committer_initial))
                 should_set_committers = False

--- a/guet/commands/setcommitters.py
+++ b/guet/commands/setcommitters.py
@@ -34,7 +34,7 @@ class SetCommittersCommand(Command):
         self._user_gateway = user_gateway
 
     def execute(self):
-        committer_initials = self._args[1:]
+        committer_initials = [initials.lower() for initials in self._args[1:]]
         committers = []
         pair_set_time = round(datetime.datetime.utcnow().timestamp() * 1000)
         pair_set_id = self._pair_set_gateway.add_pair_set(pair_set_time)
@@ -48,7 +48,7 @@ class SetCommittersCommand(Command):
                 initials = str(pair_set_committer).lower()
                 id = pair_set_id
                 self._pair_set_committers_gateway.add_pair_set_committer(initials, id)
-            author = self._user_gateway.get_user(str(committer_initials[0]).lower())
+            author = self._user_gateway.get_user(committer_initials[0])
             actual_committers = [Committer(c.name, c.email) for c in committers]
             set_committers(actual_committers)
             set_committer_as_author(actual_committers[0])
@@ -56,7 +56,7 @@ class SetCommittersCommand(Command):
     def _prepare_pair_set_committers(self, committer_initials: list, committers: list, pair_set_committer_add: list):
         should_set_committers = True
         for committer_initial in committer_initials:
-            committer = self._user_gateway.get_user(str(committer_initial).lower())
+            committer = self._user_gateway.get_user(committer_initial)
             if committer is None:
                 print("No committer exists with initials '{}'".format(committer_initial))
                 should_set_committers = False

--- a/test/commands/test_addcommitter.py
+++ b/test/commands/test_addcommitter.py
@@ -38,12 +38,12 @@ class TestAddUserCommand(CommandTest):
         mock_user_gateway = UserGateway()
         mock_user_gateway.add_user = Mock()
 
-        initials = 'usr'
+        initials = 'usR'
         name = 'user'
         email = 'user@localhost'
         command = AddUserCommand(['guet', initials, name, email], mock_user_gateway)
         command.execute()
-        mock_user_gateway.add_user.assert_called_once_with(initials, name, email)
+        mock_user_gateway.add_user.assert_called_once_with(initials.lower(), name, email)
 
     @patch('builtins.print')
     def test_execute_prints_error_message_when_too_many_arguments_are_given(self,

--- a/test/commands/test_setcommitters.py
+++ b/test/commands/test_setcommitters.py
@@ -59,12 +59,12 @@ class TestSetCommittersCommand(CommandTest):
         expected_initials = 'initials'
 
         def _mock_user_return(initials: str):
-            if initials is expected_initials:
+            if initials == expected_initials:
                 return committer_result(name='name', email='email', initials=expected_initials)
 
         self.mock_user_gateway.get_user = Mock(side_effect=_mock_user_return)
 
-        command = self._create_set_committers_command_with_all_mocks(['set', expected_initials], self.mock_user_gateway)
+        command = self._create_set_committers_command_with_all_mocks(['set', "InItIaLs"], self.mock_user_gateway)
         command.execute()
         mock_set_committer_as_author.assert_called_with(Committer('name', 'email'))
 


### PR DESCRIPTION
Hey, I tried to make the case of the initials entered unimportant as requested by someone the other day (maybe Mike?) when using 'guet set' and 'guet add'.