### PR TITLE
Block commits without set

### DIFF
--- a/e2e/test_commit.py
+++ b/e2e/test_commit.py
@@ -40,3 +40,15 @@ class TestCommit(DockerTest):
         self.execute()
         self.assert_text_in_logs(16, '    Co-authored-by: name3 <email3@localhost>')
         self.assert_text_in_logs(17, '    Co-authored-by: name4 <email4@localhost>')
+
+    def test_wont_allow_commit_if_guet_set_hasnt_been_done(self):
+        self.guet_init()
+        self.git_init()
+        self.guet_start()
+        self.add_file('A')
+        self.git_add()
+        self.git_commit('Initial commit')
+
+        self.execute()
+
+        self.assert_text_in_logs(1, 'You must set your pairs before you can commit.')

--- a/guet/config/get_current_committers.py
+++ b/guet/config/get_current_committers.py
@@ -6,18 +6,24 @@ from guet.config import CONFIGURATION_DIRECTORY
 from guet.config.committer import Committer, filter_committers_with_initials
 from guet.config.get_committers import get_committers
 
+POSITION_OF_LAST_ELEMENT = -1
+
+
+def _get_committer_with_initials(committers: List[Committer], initials: str) -> Committer:
+    return next(filter(lambda committer: committer.initials == initials, committers))
+
+
+def _committers_in_order_of_initials(committers: List[Committer],
+                                     committer_initials: List[str]) -> List[Committer]:
+    return list(map(lambda initials: _get_committer_with_initials(committers, initials), committer_initials))
+
 
 def get_current_committers() -> List[Committer]:
     set_committers_file = open(join(CONFIGURATION_DIRECTORY, constants.COMMITTERS_SET), 'r')
     line = set_committers_file.readline()
     set_committers_file.close()
     committer_initials = line.rstrip().split(',')
-    del committer_initials[-1]
+    del committer_initials[POSITION_OF_LAST_ELEMENT]
     committers = get_committers()
     committers_with_initials = filter_committers_with_initials(committers, committer_initials)
-    final = []
-    for initials in committer_initials:
-        for committer in committers_with_initials:
-            if committer.initials == initials:
-                final.append(committer)
-    return final
+    return _committers_in_order_of_initials(committers_with_initials, committer_initials)

--- a/guet/hooks/pre_commit.py
+++ b/guet/hooks/pre_commit.py
@@ -1,4 +1,5 @@
 from guet.config.get_config import get_config
+from guet.config.get_current_committers import get_current_committers
 from guet.config.most_recent_committers_set import most_recent_committers_set
 from guet.currentmillis import current_millis
 from guet.util.errors import log_on_error
@@ -6,13 +7,16 @@ from guet.util.errors import log_on_error
 
 @log_on_error
 def pre_commit():
-    _check_within_timeframe_if_enabled()
-
-
-def _check_within_timeframe_if_enabled():
     settings = get_config()
-    if settings.read('pairReset'):
+    if len(get_current_committers()) == 0:
+        _fail_because_there_are_no_current_committers()
+    elif settings.read('pairReset'):
         _fail_if_past_valid_timeframe()
+
+
+def _fail_because_there_are_no_current_committers():
+    print('You must set your pairs before you can commit.\n')
+    exit(1)
 
 
 def _fail_if_past_valid_timeframe():


### PR DESCRIPTION
## Overview
Implements feature to block commits if `guet set` hasn't been done yet.

Fixes #28 

### Demo
```
$ git init
$ guet start

# implement some changes

$ git commit -m "Commit changes"
You must set your pairs before you can commit.
```
