### PR TITLE
Scoped guet set

### DIFF
--- a/e2e/dockertest/docker_test.py
+++ b/e2e/dockertest/docker_test.py
@@ -46,6 +46,7 @@ class DockerTest(unittest.TestCase):
         self.files_to_save = []
 
     def execute(self):
+        self.save_file_content('.guet/config')
         docker_client = docker.from_env()
         self.execute_command = self._generate_commands_string_to_pass_to_run()
         container = docker_client.containers.run('guettest:0.1.0',

--- a/e2e/dockertest/docker_test.py
+++ b/e2e/dockertest/docker_test.py
@@ -62,6 +62,12 @@ class DockerTest(unittest.TestCase):
         docker_client.close()
         self.execute_called = True
 
+    def change_directory(self, path: str):
+        self.add_command(f'cd {path}')
+
+    def return_to_default_directory(self):
+        self.add_command('cd ~/test-env')
+
     @_called_execute
     def guet_init(self, arguments: List[str] = None):
         self.init_called = True
@@ -107,7 +113,7 @@ class DockerTest(unittest.TestCase):
         self.add_command(command)
 
     @_called_execute
-    def git_init(self):
+    def git_init(self, from_path: str = None):
         self.add_command('git init')
         self.add_command('git config --global user.name name')
         self.add_command('git config --global user.email email')

--- a/e2e/dockertest/docker_test.py
+++ b/e2e/dockertest/docker_test.py
@@ -44,9 +44,11 @@ class DockerTest(unittest.TestCase):
         self.execute_called = False
         self.commands = []
         self.files_to_save = []
+        self.init_called = False
 
     def execute(self):
-        self.save_file_content('.guet/config')
+        if self.init_called:
+            self.save_file_content('.guet/config')
         docker_client = docker.from_env()
         self.execute_command = self._generate_commands_string_to_pass_to_run()
         container = docker_client.containers.run('guettest:0.1.0',
@@ -62,6 +64,7 @@ class DockerTest(unittest.TestCase):
 
     @_called_execute
     def guet_init(self, arguments: List[str] = None):
+        self.init_called = True
         command = 'guet init'
         if arguments:
             command = command + ' ' + ' '.join(arguments)

--- a/e2e/test_commit.py
+++ b/e2e/test_commit.py
@@ -52,3 +52,20 @@ class TestCommit(DockerTest):
         self.execute()
 
         self.assert_text_in_logs(1, 'You must set your pairs before you can commit.')
+
+    def test_wont_allow_commits_in_guet_repo_if_pairs_havent_been_set_in_that_repo(self):
+        self.guet_init()
+        self.guet_add('initials', 'name', 'email@localhost')
+        self.guet_add('initials2', 'name2', 'email2@localhost')
+        self.guet_set(['initials', 'initials2'])
+        self.add_command('mkdir test')
+        self.change_directory('test')
+        self.git_init()
+        self.guet_start()
+        self.add_file('A')
+        self.git_add()
+        self.git_commit('Initial commit')
+
+        self.execute()
+
+        self.assert_text_in_logs(1, 'You must set your pairs before you can commit.')

--- a/guet/config/get_current_committers.py
+++ b/guet/config/get_current_committers.py
@@ -6,6 +6,7 @@ from guet.config import CONFIGURATION_DIRECTORY
 from guet.config.committer import Committer, filter_committers_with_initials
 from guet.config.get_committers import get_committers
 from guet.files.read_lines import read_lines
+from guet.git.git_path_from_cwd import git_path_from_cwd
 
 POSITION_OF_LAST_ELEMENT = -1
 
@@ -21,6 +22,8 @@ def _committers_in_order_of_initials(committers: List[Committer],
 
 def _process_lines_from_committer_set(lines: List[str]) -> List[Committer]:
     *committer_initials, set_time, path_to_git = lines[0].rstrip().split(',')
+    if path_to_git != git_path_from_cwd():
+        return []
     committers = get_committers()
     committers_with_initials = filter_committers_with_initials(committers, committer_initials)
     return _committers_in_order_of_initials(committers_with_initials, committer_initials)

--- a/guet/config/get_current_committers.py
+++ b/guet/config/get_current_committers.py
@@ -20,7 +20,7 @@ def _committers_in_order_of_initials(committers: List[Committer],
 
 
 def _process_lines_from_committer_set(lines: List[str]) -> List[Committer]:
-    *committer_initials, set_time = lines[0].rstrip().split(',')
+    *committer_initials, set_time, path_to_git = lines[0].rstrip().split(',')
     committers = get_committers()
     committers_with_initials = filter_committers_with_initials(committers, committer_initials)
     return _committers_in_order_of_initials(committers_with_initials, committer_initials)

--- a/guet/config/most_recent_committers_set.py
+++ b/guet/config/most_recent_committers_set.py
@@ -2,11 +2,12 @@ from os.path import join
 
 from guet import constants
 from guet.config import CONFIGURATION_DIRECTORY
+from guet.files.read_lines import read_lines
+from guet.config.parse_comitters_set_line import parse_committers_set_line
 
 
 def most_recent_committers_set():
-    set_committers_file = open(join(CONFIGURATION_DIRECTORY, constants.COMMITTERS_SET), 'r')
-    line = set_committers_file.readline()
-    set_committers_file.close()
-    split = line.rstrip().split(',')
-    return int(split[len(split)-1])
+    path = join(CONFIGURATION_DIRECTORY, constants.COMMITTERS_SET)
+    lines = read_lines(path)
+    *committer_initials, set_time = parse_committers_set_line(lines[0])
+    return int(set_time)

--- a/guet/config/most_recent_committers_set.py
+++ b/guet/config/most_recent_committers_set.py
@@ -9,5 +9,5 @@ from guet.config.parse_comitters_set_line import parse_committers_set_line
 def most_recent_committers_set():
     path = join(CONFIGURATION_DIRECTORY, constants.COMMITTERS_SET)
     lines = read_lines(path)
-    *committer_initials, set_time = parse_committers_set_line(lines[0])
+    *committer_initials, set_time, path_to_git = parse_committers_set_line(lines[0])
     return int(set_time)

--- a/guet/config/parse_comitters_set_line.py
+++ b/guet/config/parse_comitters_set_line.py
@@ -1,0 +1,2 @@
+def parse_committers_set_line(line: str):
+    return line.rstrip().split(',')

--- a/guet/config/set_current_committers.py
+++ b/guet/config/set_current_committers.py
@@ -5,13 +5,15 @@ from typing import List
 from guet import constants
 from guet.config import CONFIGURATION_DIRECTORY
 from guet.config.committer import Committer
+from guet.files.write_lines import write_lines
+from guet.files.read_lines import read_lines
 from guet.git.git_path_from_cwd import git_path_from_cwd
 
 
 def set_current_committers(committers: List[Committer]) -> None:
-    committers_set_file = open(join(CONFIGURATION_DIRECTORY, constants.COMMITTERS_SET), 'w')
-    committers_set_file.write(_format_committers_to_committers_set_format(committers))
-    committers_set_file.close()
+    path = join(CONFIGURATION_DIRECTORY, constants.COMMITTERS_SET)
+    lines = [_format_committers_to_committers_set_format(committers)]
+    write_lines(path, lines)
 
 
 def _format_committers_to_committers_set_format(committers: List[Committer]) -> str:

--- a/guet/config/set_current_committers.py
+++ b/guet/config/set_current_committers.py
@@ -5,6 +5,7 @@ from typing import List
 from guet import constants
 from guet.config import CONFIGURATION_DIRECTORY
 from guet.config.committer import Committer
+from guet.git.git_path_from_cwd import git_path_from_cwd
 
 
 def set_current_committers(committers: List[Committer]) -> None:
@@ -14,6 +15,7 @@ def set_current_committers(committers: List[Committer]) -> None:
 
 
 def _format_committers_to_committers_set_format(committers: List[Committer]) -> str:
+    git_path = git_path_from_cwd()
     current_time_in_millis = int(round(time.time() * 1000))
     committer_initials = ','.join([committer.initials for committer in committers])
-    return committer_initials + f',{current_time_in_millis}\n'
+    return committer_initials + f',{current_time_in_millis},{git_path}\n'

--- a/test/config/test_get_current_committers.py
+++ b/test/config/test_get_current_committers.py
@@ -21,7 +21,7 @@ class TestGetCurrentCommitters(unittest.TestCase):
             Committer('name1', 'email1', 'initials1'),
             Committer('name2', 'email2', 'initials2')
         ]
-        mock_read_lines.return_value = ['initials1,initials2,1000000000\n']
+        mock_read_lines.return_value = ['initials1,initials2,1000000000,/absolute/path/to/.git\n']
 
         committers = get_current_committers()
         self.assertEqual(committers[0].name, 'name1')
@@ -34,7 +34,7 @@ class TestGetCurrentCommitters(unittest.TestCase):
     def test_reads_committers_from_file(self,
                                         mock_read_lines,
                                         mock_get_committers):
-        mock_read_lines.return_value = ['initials1,initials2,1000000000\n']
+        mock_read_lines.return_value = ['initials1,initials2,1000000000,/absolute/path/to/.git\n']
         get_current_committers()
         mock_read_lines.assert_called_with(join(CONFIGURATION_DIRECTORY, constants.COMMITTERS_SET))
 
@@ -46,7 +46,7 @@ class TestGetCurrentCommitters(unittest.TestCase):
             Committer('name1', 'email1', 'initials1'),
             Committer('name2', 'email2', 'initials2')
         ]
-        mock_read_lines.return_value = ['initials2,initials1,1000000000\n']
+        mock_read_lines.return_value = ['initials2,initials1,1000000000,/absolute/path/to/.git\n']
 
         committers = get_current_committers()
         self.assertEqual(committers[0].name, 'name2')

--- a/test/config/test_most_recent_committers_set.py
+++ b/test/config/test_most_recent_committers_set.py
@@ -9,6 +9,6 @@ class TestMostRecentCommittersSet(unittest.TestCase):
 
     def test_gets_the_timestamp_from_committers_set(self,
                                                     mock_read_lines):
-        mock_read_lines.return_value = ['initials1,initials2,1000000000']
+        mock_read_lines.return_value = ['initials1,initials2,1000000000,/absolute/path/to/.git']
         result = most_recent_committers_set()
         self.assertEqual(1000000000, result)

--- a/test/config/test_most_recent_committers_set.py
+++ b/test/config/test_most_recent_committers_set.py
@@ -4,12 +4,11 @@ from unittest.mock import patch, mock_open
 from guet.config.most_recent_committers_set import most_recent_committers_set
 
 
-@patch('builtins.open', new_callable=mock_open())
+@patch('guet.config.most_recent_committers_set.read_lines')
 class TestMostRecentCommittersSet(unittest.TestCase):
 
     def test_gets_the_timestamp_from_committers_set(self,
-                                                    mock_open):
-
-        mock_open.return_value.readline.return_value = 'initials1,initials2,1000000000\n'
+                                                    mock_read_lines):
+        mock_read_lines.return_value = ['initials1,initials2,1000000000']
         result = most_recent_committers_set()
         self.assertEqual(1000000000, result)

--- a/test/config/test_set_current_committers.py
+++ b/test/config/test_set_current_committers.py
@@ -10,15 +10,19 @@ from guet.config.set_current_committers import set_current_committers
 
 class TestSetCurrentCommitters(unittest.TestCase):
 
+    @patch('guet.config.set_current_committers.read_lines')
+    @patch('guet.config.set_current_committers.write_lines')
     @patch('guet.config.set_current_committers.git_path_from_cwd')
     @patch('time.time')
-    @patch('builtins.open', new_callable=mock_open())
     def test_writes_committer_initials_and_current_time_to_committers_set_file(self,
-                                                                               mock_open,
                                                                                mock_time,
-                                                                               mock_git_path):
+                                                                               mock_git_path,
+                                                                               mock_write_lines,
+                                                                               mock_read_lines):
+        mock_read_lines.return_value = []
         mock_git_path.return_value = '/absolute/path/to/.git'
         mock_time.return_value = 1000000000
         set_current_committers([Committer('name', 'email', 'initials1'), Committer('name', 'email', 'initials2')])
-        mock_open.assert_called_with(join(CONFIGURATION_DIRECTORY, constants.COMMITTERS_SET), 'w')
-        mock_open.return_value.write.assert_called_with('initials1,initials2,1000000000000,/absolute/path/to/.git\n')
+
+        mock_write_lines.assert_called_with(join(CONFIGURATION_DIRECTORY, constants.COMMITTERS_SET),
+                                            ['initials1,initials2,1000000000000,/absolute/path/to/.git'])

--- a/test/config/test_set_current_committers.py
+++ b/test/config/test_set_current_committers.py
@@ -25,4 +25,4 @@ class TestSetCurrentCommitters(unittest.TestCase):
         set_current_committers([Committer('name', 'email', 'initials1'), Committer('name', 'email', 'initials2')])
 
         mock_write_lines.assert_called_with(join(CONFIGURATION_DIRECTORY, constants.COMMITTERS_SET),
-                                            ['initials1,initials2,1000000000000,/absolute/path/to/.git'])
+                                            ['initials1,initials2,1000000000000,/absolute/path/to/.git\n'])

--- a/test/config/test_set_current_committers.py
+++ b/test/config/test_set_current_committers.py
@@ -10,12 +10,15 @@ from guet.config.set_current_committers import set_current_committers
 
 class TestSetCurrentCommitters(unittest.TestCase):
 
+    @patch('guet.config.set_current_committers.git_path_from_cwd')
     @patch('time.time')
     @patch('builtins.open', new_callable=mock_open())
     def test_writes_committer_initials_and_current_time_to_committers_set_file(self,
                                                                                mock_open,
-                                                                               mock_time):
+                                                                               mock_time,
+                                                                               mock_git_path):
+        mock_git_path.return_value = '/absolute/path/to/.git'
         mock_time.return_value = 1000000000
         set_current_committers([Committer('name', 'email', 'initials1'), Committer('name', 'email', 'initials2')])
         mock_open.assert_called_with(join(CONFIGURATION_DIRECTORY, constants.COMMITTERS_SET), 'w')
-        mock_open.return_value.write.assert_called_with('initials1,initials2,1000000000000\n')
+        mock_open.return_value.write.assert_called_with('initials1,initials2,1000000000000,/absolute/path/to/.git\n')


### PR DESCRIPTION
## Overview
Scopes a `guet set` to a particular repo.

Connects #17 

### Demo
When considering `projectA` and `projectB`, the following workflow can be expected:
```
$ cd projectA
$ guet set cb
$ git commit -m "commit message"
$ cd ../projectB
$ git commit -m "commit message"
You must set committer
```

### Notes
Because of the implementation, a `guet set` in `projectA` would overwrite a `guet set` in `projectB`, so on the next commit to `projectB` you would have to `guet set` again. Another issue has been opened to address multiple `guet sets` on a computer. Issue #34 tracks this problem.