### PR TITLE
Print version when the --version/-v flag is present

### DIFF
--- a/e2e/test_version.py
+++ b/e2e/test_version.py
@@ -1,0 +1,10 @@
+import guet
+from e2e import DockerTest
+
+
+class TestAddUser(DockerTest):
+
+    def test_prints_version(self):
+        self.add_command('guet --version')
+        self.execute()
+        self.assert_text_in_logs(0, guet.__version__)

--- a/guet/factory.py
+++ b/guet/factory.py
@@ -1,10 +1,10 @@
-from typing import List
 
-from guet.commands.argsettingcommand import ArgSettingCommand
+import guet
 from guet.commands.command import Command
 from guet.commands.command_factory import CommandFactoryMethod
 from guet.commands.help.guet_usage import guet_usage
 from guet.commands.help_message_strategy import HelpMessageStrategy
+from guet.commands.print_strategy import PrintCommandStrategy
 from guet.commands.strategy_command import StrategyCommand
 from guet.settings.settings import Settings
 from guet.config.get_config import get_config
@@ -15,30 +15,18 @@ class CommandFactory:
     def __init__(self, command_builder_map):
         self.command_builder_map = command_builder_map
 
-    def create(self, args: list) -> ArgSettingCommand:
-        result = None
-        if already_initialized():
-            result = self._create_with_settings(args, get_config())
+    def create(self, args: list) -> Command:
+        if '--version' in args or '-v' in args:
+            return StrategyCommand(PrintCommandStrategy(guet.__version__))
+        elif already_initialized():
+            return self._create_with_settings(args, get_config())
         else:
-            result = self._create_with_settings(args, Settings())
-        return result
+            return self._create_with_settings(args, Settings())
 
     def _create_with_settings(self, args: list, settings: Settings) -> Command:
         if len(args) > 0:
             command_arg = args[0]
-            command_type = self.command_builder_map[command_arg]
-            if isinstance(command_type, CommandFactoryMethod):
-                return self._create_with_command_factory(command_type, args, settings)
-            else:
-                return self._create_with_command_constructor(command_type, args, settings)
-
+            command_factory: CommandFactoryMethod = self.command_builder_map[command_arg]
+            return command_factory.build(args, settings)
         else:
             return StrategyCommand(HelpMessageStrategy(guet_usage(self.command_builder_map)))
-
-    def _create_with_command_constructor(self, command_class, args: List[str],
-                                         settings: Settings) -> ArgSettingCommand:
-        return command_class(args, settings)
-
-    def _create_with_command_factory(self, command_factory: CommandFactoryMethod, args: List[str],
-                                     settings: Settings) -> ArgSettingCommand:
-        return command_factory.build(args, settings)

--- a/test/test_factory.py
+++ b/test/test_factory.py
@@ -1,102 +1,57 @@
 import unittest
-from typing import List
-from unittest.mock import patch
+from unittest.mock import patch, Mock
+import guet
 from guet.commands.help.guet_usage import guet_usage
-from guet.commands.argsettingcommand import ArgSettingCommand
-from guet.commands.command_factory import CommandFactoryMethod
 from guet.factory import CommandFactory
-from guet.settings.settings import Settings
 
 
 @patch('guet.factory.already_initialized', return_value=True)
 @patch('guet.factory.get_config')
 class TestCommandFactory(unittest.TestCase):
-    def test_returns_command_from_builder_method_that_matches(self, mock_get_settings,
-                                                              mock_already_init):
-        builder_map = dict()
-        builder_map['command'] = MockCommand
-        builder_map['not-command'] = NotMockCommand
-
-        command_factory = CommandFactory(builder_map)
-        args = ['command']
-        result = command_factory.create(args)
-        self.assertEqual(MockCommand, type(result))
 
     def test_returns_command_with_settings_from_settings_file(self, mock_get_settings,
                                                               mock_already_init):
-        expected_settings = Settings()
-        mock_get_settings.return_value = expected_settings
         builder_map = dict()
-        builder_map['command'] = MockCommand
-        builder_map['not-command'] = NotMockCommand
+        mock_factory = Mock()
+        builder_map['command'] = mock_factory
 
         command_factory = CommandFactory(builder_map)
         args = ['command']
-        result = command_factory.create(args)
-        self.assertEqual(expected_settings, result.settings)
-
-    def test_uses_new_settings_with_default_values_if_initialization_hasnt_been_ran(
-            self, mock_get_settings, mock_already_init):
-        mock_already_init.return_value = False
-        returned_settings = Settings()
-        mock_get_settings.return_value = returned_settings
-        builder_map = dict()
-        builder_map['command'] = MockCommand
-
-        command_factory = CommandFactory(builder_map)
-        args = ['command']
-        result = command_factory.create(args)
-        self.assertNotEqual(returned_settings, result.settings)
+        command_factory.create(args)
+        mock_factory.build.assert_called_with(args, mock_get_settings.return_value)
 
     @patch('builtins.print')
     def test_uses_command_builder_map_to_print_help_messages(self, mock_print, mock_get_settings,
                                                              mock_already_init):
         builder_map = dict()
-        builder_map['command'] = MockCommandFactory()
+        builder_map['command'] = Mock()
         command_factory = CommandFactory(builder_map)
         result = command_factory.create([])
         result.execute()
         mock_print.assert_called_with(guet_usage(builder_map))
 
-    def test_returns_command_using_command_factory_build_method(self, mock_get_settings,
-                                                                mock_already_init):
+    @patch('builtins.print')
+    def test_returns_command_that_prints_version_when_given_dash_dash_version_flag(self, mock_print,
+                                                                                   mock_get_settings,
+                                                                                   mock_already_init):
         builder_map = dict()
-        builder_map['command'] = MockCommandFactory()
-        builder_map['not-command'] = NotMockCommand
+        builder_map['command'] = Mock()
 
         command_factory = CommandFactory(builder_map)
-        args = ['command']
-        result = command_factory.create(args)
-        self.assertEqual(MockCommand, type(result))
 
+        result = command_factory.create(['--version'])
+        result.execute()
+        mock_print.assert_called_with(f'{guet.__version__}')
 
-class MockCommand(ArgSettingCommand):
-    def execute_hook(self) -> None:
-        pass
+    @patch('builtins.print')
+    def test_returns_command_that_prints_version_when_given_dash_v(self, mock_print,
+                                                                   mock_get_settings,
+                                                                   mock_already_init):
+        builder_map = dict()
+        builder_map['command'] = Mock()
 
-    def help(self) -> str:
-        pass
+        command_factory = CommandFactory(builder_map)
 
-    @classmethod
-    def help_short(cls) -> str:
-        pass
-
-
-class NotMockCommand(ArgSettingCommand):
-    def execute_hook(self) -> None:
-        pass
-
-    def help(self) -> str:
-        pass
-
-    @classmethod
-    def help_short(cls) -> str:
-        pass
-
-
-class MockCommandFactory(CommandFactoryMethod):
-    def short_help_message(self):
-        pass
-
-    def build(self, args: List[str], settings: Settings):
-        return MockCommand(args, settings)
+        result = command_factory.create(['-v'])
+        result.execute()
+        mock_print.assert_called_with(f'{guet.__version__}')


### PR DESCRIPTION
## Overview
Adds flag for printing the version of `guet`.

Connects #36 

### Demo
```
$ guet --version
2.2.0
```

### Notes
Because of the implementation, putting `--version` on any command will print the version instead of doing whatever command was. For example `guet get current --version` will print `2.2.0`.