### PR TITLE
Allow multiple guet sets at the same time between repos

### DIFF
--- a/e2e/test_commit.py
+++ b/e2e/test_commit.py
@@ -69,3 +69,23 @@ class TestCommit(DockerTest):
         self.execute()
 
         self.assert_text_in_logs(1, 'You must set your pairs before you can commit.')
+
+    def test_can_make_committs_in_multiple_repos_with_committers_set(self):
+        self.guet_init()
+        self.guet_add('initials', 'name', 'email@localhost')
+        self.guet_add('initials2', 'name2', 'email2@localhost')
+        self.guet_set(['initials', 'initials2'])
+        self.add_command('mkdir test')
+        self.change_directory('test')
+        self.git_init()
+        self.guet_start()
+        self.guet_set(['initials', 'initials2'])
+        self.add_file('A')
+        self.git_add()
+        self.git_commit('Initial commit')
+        self.show_git_log()
+
+        self.execute()
+
+        self.assert_text_in_logs(10, '    Co-authored-by: name <email@localhost>')
+        self.assert_text_in_logs(11, '    Co-authored-by: name2 <email2@localhost>')

--- a/guet/config/get_current_committers.py
+++ b/guet/config/get_current_committers.py
@@ -12,7 +12,7 @@ POSITION_OF_LAST_ELEMENT = -1
 
 
 def _get_committer_with_initials(committers: List[Committer], initials: str) -> Committer:
-    return next(filter(lambda committer: committer.initials == initials, committers))
+    return next(committer for committer in committers if committer.initials == initials)
 
 
 def _committers_in_order_of_initials(committers: List[Committer],
@@ -20,10 +20,16 @@ def _committers_in_order_of_initials(committers: List[Committer],
     return list(map(lambda initials: _get_committer_with_initials(committers, initials), committer_initials))
 
 
+def _line_ending_with_git_path(lines: List[str]) -> str:
+    git_path = git_path_from_cwd()
+    return next((line for line in lines if line.endswith(git_path)), None)
+
+
 def _process_lines_from_committer_set(lines: List[str]) -> List[Committer]:
-    *committer_initials, set_time, path_to_git = lines[0].rstrip().split(',')
-    if path_to_git != git_path_from_cwd():
+    line = _line_ending_with_git_path(lines)
+    if not line:
         return []
+    *committer_initials, set_time, path_to_git = line.split(',')
     committers = get_committers()
     committers_with_initials = filter_committers_with_initials(committers, committer_initials)
     return _committers_in_order_of_initials(committers_with_initials, committer_initials)

--- a/guet/config/set_current_committers.py
+++ b/guet/config/set_current_committers.py
@@ -10,14 +10,30 @@ from guet.files.read_lines import read_lines
 from guet.git.git_path_from_cwd import git_path_from_cwd
 
 
-def set_current_committers(committers: List[Committer]) -> None:
-    path = join(CONFIGURATION_DIRECTORY, constants.COMMITTERS_SET)
-    lines = [_format_committers_to_committers_set_format(committers)]
-    write_lines(path, lines)
+def _all_committers_set_from_file() -> List[str]:
+    return read_lines(join(CONFIGURATION_DIRECTORY, constants.COMMITTERS_SET))
 
 
 def _format_committers_to_committers_set_format(committers: List[Committer]) -> str:
     git_path = git_path_from_cwd()
     current_time_in_millis = int(round(time.time() * 1000))
     committer_initials = ','.join([committer.initials for committer in committers])
-    return committer_initials + f',{current_time_in_millis},{git_path}\n'
+    return committer_initials + f',{current_time_in_millis},{git_path}'
+
+
+def _add_to_current_set_lines(current_set, formatted_set_committers_information):
+    git_path = git_path_from_cwd()
+    line_with_git_path = next((line for line in current_set if line.endswith(git_path)), None)
+    if line_with_git_path:
+        index = current_set.index(line_with_git_path)
+        current_set[index] = formatted_set_committers_information
+    else:
+        current_set.append(formatted_set_committers_information)
+
+
+def set_current_committers(committers: List[Committer]) -> None:
+    path = join(CONFIGURATION_DIRECTORY, constants.COMMITTERS_SET)
+    current_set = _all_committers_set_from_file()
+    formatted_set_committers_information = _format_committers_to_committers_set_format(committers)
+    _add_to_current_set_lines(current_set, formatted_set_committers_information)
+    write_lines(path, current_set)

--- a/guet/files/read_lines.py
+++ b/guet/files/read_lines.py
@@ -3,6 +3,6 @@ from typing import List
 
 def read_lines(path: str) -> List[str]:
     file = open(path, 'r')
-    lines = file.readlines()
+    lines = [line.rstrip() for line in file.readlines()]
     file.close()
     return lines

--- a/test/config/test_set_current_committers.py
+++ b/test/config/test_set_current_committers.py
@@ -25,4 +25,47 @@ class TestSetCurrentCommitters(unittest.TestCase):
         set_current_committers([Committer('name', 'email', 'initials1'), Committer('name', 'email', 'initials2')])
 
         mock_write_lines.assert_called_with(join(CONFIGURATION_DIRECTORY, constants.COMMITTERS_SET),
-                                            ['initials1,initials2,1000000000000,/absolute/path/to/.git\n'])
+                                            ['initials1,initials2,1000000000000,/absolute/path/to/.git'])
+
+    @patch('guet.config.set_current_committers.read_lines')
+    @patch('guet.config.set_current_committers.write_lines')
+    @patch('guet.config.set_current_committers.git_path_from_cwd')
+    @patch('time.time')
+    def test_adds_given_committer_initials_to_committers_set_file(self,
+                                                                  mock_time,
+                                                                  mock_git_path,
+                                                                  mock_write_lines,
+                                                                  mock_read_lines):
+        mock_read_lines.return_value = [
+            'initials3,initials4,1000000000000,/absolute/path/to/other/.git',
+        ]
+        mock_git_path.return_value = '/absolute/path/to/.git'
+        mock_time.return_value = 1000000000
+        set_current_committers([Committer('name', 'email', 'initials1'), Committer('name', 'email', 'initials2')])
+
+        lines = [
+            'initials3,initials4,1000000000000,/absolute/path/to/other/.git',
+            'initials1,initials2,1000000000000,/absolute/path/to/.git'
+        ]
+        mock_write_lines.assert_called_with(join(CONFIGURATION_DIRECTORY, constants.COMMITTERS_SET), lines)
+
+    @patch('guet.config.set_current_committers.read_lines')
+    @patch('guet.config.set_current_committers.write_lines')
+    @patch('guet.config.set_current_committers.git_path_from_cwd')
+    @patch('time.time')
+    def test_overwrites_set_initials_if_git_path_matches(self,
+                                                         mock_time,
+                                                         mock_git_path,
+                                                         mock_write_lines,
+                                                         mock_read_lines):
+        mock_read_lines.return_value = [
+            'initials1,initials2,1000000,/absolute/path/to/.git',
+        ]
+        mock_git_path.return_value = '/absolute/path/to/.git'
+        mock_time.return_value = 1000000000
+        set_current_committers([Committer('name', 'email', 'initials3'), Committer('name', 'email', 'initials4')])
+
+        lines = [
+            'initials3,initials4,1000000000000,/absolute/path/to/.git'
+        ]
+        mock_write_lines.assert_called_with(join(CONFIGURATION_DIRECTORY, constants.COMMITTERS_SET), lines)

--- a/test/files/test_read_lines.py
+++ b/test/files/test_read_lines.py
@@ -14,8 +14,8 @@ class TestReadLines(unittest.TestCase):
     @patch('builtins.open', new_callable=mock_open())
     def test_returns_lines_from_file(self, mock_open):
         expected = [
-            'Line1\n',
-            'Line2\n'
+            'Line1',
+            'Line2'
         ]
         mock_open.return_value.readlines.return_value = expected
         result = read_lines('path/to/file')
@@ -25,3 +25,13 @@ class TestReadLines(unittest.TestCase):
     def test_closes_file(self, mock_open):
         read_lines('path/to/file')
         mock_open.return_value.close.assert_called()
+
+    @patch('builtins.open', new_callable=mock_open())
+    def test_strips_newlines_from_the_end_of_lines(self, mock_open):
+        expected = [
+            'Line1\n',
+            'Line2\n'
+        ]
+        mock_open.return_value.readlines.return_value = expected
+        result = read_lines('path/to/file')
+        self.assertEqual(['Line1', 'Line2'], result)


### PR DESCRIPTION
## Overview
Adds the ability to keep track of multiple `guet sets` in different projects. The corrects the implementation in #17.

Connects #34

### Demo
```
$ cd projectA
$ guet set cb op
$ guet get current
Currently set committers
cb - chris boyer <chris@email.com>
op - other person <other@email.com>
$ cd ../projectB
$ guet set oop cb
$ guet get current
Currently set committers
cb - chris boyer <chris@email.com>
oop - other other person <otherother@email.com>
```