### PR TITLE
Running set in non git folders

### DIFF
--- a/e2e/test_commit.py
+++ b/e2e/test_commit.py
@@ -55,11 +55,14 @@ class TestCommit(DockerTest):
 
     def test_wont_allow_commits_in_guet_repo_if_pairs_havent_been_set_in_that_repo(self):
         self.guet_init()
+        self.add_command('mkdir test1')
+        self.change_directory('test1')
         self.guet_add('initials', 'name', 'email@localhost')
         self.guet_add('initials2', 'name2', 'email2@localhost')
         self.guet_set(['initials', 'initials2'])
-        self.add_command('mkdir test')
-        self.change_directory('test')
+        self.change_directory('..')
+        self.add_command('mkdir test2')
+        self.change_directory('test2')
         self.git_init()
         self.guet_start()
         self.add_file('A')
@@ -68,15 +71,18 @@ class TestCommit(DockerTest):
 
         self.execute()
 
-        self.assert_text_in_logs(1, 'You must set your pairs before you can commit.')
+        self.assert_text_in_logs(2, 'You must set your pairs before you can commit.')
 
     def test_can_make_committs_in_multiple_repos_with_committers_set(self):
         self.guet_init()
+        self.add_command('mkdir test1')
+        self.change_directory('test1')
         self.guet_add('initials', 'name', 'email@localhost')
         self.guet_add('initials2', 'name2', 'email2@localhost')
         self.guet_set(['initials', 'initials2'])
-        self.add_command('mkdir test')
-        self.change_directory('test')
+        self.change_directory('..')
+        self.add_command('mkdir test2')
+        self.change_directory('test2')
         self.git_init()
         self.guet_start()
         self.guet_set(['initials', 'initials2'])
@@ -87,5 +93,5 @@ class TestCommit(DockerTest):
 
         self.execute()
 
-        self.assert_text_in_logs(10, '    Co-authored-by: name <email@localhost>')
-        self.assert_text_in_logs(11, '    Co-authored-by: name2 <email2@localhost>')
+        self.assert_text_in_logs(11, '    Co-authored-by: name <email@localhost>')
+        self.assert_text_in_logs(12, '    Co-authored-by: name2 <email2@localhost>')

--- a/e2e/test_get.py
+++ b/e2e/test_get.py
@@ -4,6 +4,7 @@ from e2e import DockerTest
 class TestGet(DockerTest):
     def test_get_current_prints_currently_set_committers(self):
         self.guet_init()
+        self.git_init()
         self.guet_add('initials1', 'name1', 'email1')
         self.guet_add('initials2', 'name2', 'email2')
         self.guet_set(['initials1', 'initials2'])
@@ -12,15 +13,14 @@ class TestGet(DockerTest):
 
         self.execute()
 
-        self.assert_text_in_logs(0, 'Currently set committers')
-        self.assert_text_in_logs(1, 'initials1 - name1 <email1>')
-        self.assert_text_in_logs(2, 'initials2 - name2 <email2>')
+        self.assert_text_in_logs(1, 'Currently set committers')
+        self.assert_text_in_logs(2, 'initials1 - name1 <email1>')
+        self.assert_text_in_logs(3, 'initials2 - name2 <email2>')
 
     def test_get_committers_prints_all_committers_on_the_system(self):
         self.guet_init()
         self.guet_add('initials1', 'name1', 'email1')
         self.guet_add('initials2', 'name2', 'email2')
-        self.guet_set(['initials1', 'initials2'])
         self.guet_get_committers()
         self.save_file_content('.guet/errors')
 

--- a/e2e/test_setcommitter.py
+++ b/e2e/test_setcommitter.py
@@ -5,18 +5,19 @@ from guet.commands.init_required_decorator import INIT_REQUIRED_ERROR_MESSAGE
 
 
 class TestGuetSet(DockerTest):
-    def test_set_gracefully_displays_error_message_when_setting_committer_with_unknown_initials(
-            self):
+    def test_set_gracefully_displays_error_message_when_setting_committer_with_unknown_initials(self):
         self.guet_init()
+        self.git_init()
         self.guet_set(['ui'])
 
         self.execute()
 
-        self.assert_text_in_logs(0, "No committer exists with initials 'ui'")
+        self.assert_text_in_logs(1, "No committer exists with initials 'ui'")
 
     def test_adds_committer_initials_and_current_millis_to_committersset_file(self):
         start_time = int(round(time.time() * 1000))
         self.guet_init()
+        self.git_init()
         self.guet_add('initials1', 'name1', 'email1')
         self.guet_add('initials2', 'name2', 'email2')
         self.guet_set(['initials1', 'initials2'])
@@ -40,6 +41,17 @@ class TestGuetSet(DockerTest):
 
     def test_set_committers_displays_help_message_when_no_initials_given(self):
         self.guet_init()
+        self.git_init()
         self.guet_set([])
         self.execute()
-        self.assert_text_in_logs(0, 'usage: guet set <initials> [<initials> ...]')
+        self.assert_text_in_logs(1, 'usage: guet set <initials> [<initials> ...]')
+
+    def test_errors_if_guet_set_ran_in_folder_with_no_git(self):
+        self.guet_init()
+        self.guet_add('initials1', 'name1', 'email1')
+        self.guet_add('initials2', 'name2', 'email2')
+        self.guet_set(['initials1', 'initials2'])
+
+        self.execute()
+
+        self.assert_text_in_logs(0, 'Git not initialized in this directory.')

--- a/guet/commands/git_required_decorator.py
+++ b/guet/commands/git_required_decorator.py
@@ -1,0 +1,16 @@
+from typing import List
+
+from guet.commands.command import Command
+from guet.commands.command_factory_decorator import CommandFactoryDecorator
+from guet.commands.print_strategy import PrintCommandStrategy
+from guet.commands.strategy_command import StrategyCommand
+from guet.git.git_present_in_cwd import git_present_in_cwd
+from guet.settings.settings import Settings
+
+
+class GitRequiredDecorator(CommandFactoryDecorator):
+    def build(self, args: List[str], settings: Settings) -> Command:
+        if git_present_in_cwd():
+            return self.decorated.build(args, settings)
+        else:
+            return StrategyCommand(PrintCommandStrategy('Git not initialized in this directory.'))

--- a/guet/commands/start/factory.py
+++ b/guet/commands/start/factory.py
@@ -25,16 +25,13 @@ class StartCommandFactory(CommandFactoryMethod):
         return 'Start guet usage in the repository at current directory'
 
     def build(self, args: List[str], settings: Settings) -> Command:
-        if git_present_in_cwd():
-            hook_path = git_hook_path_from_cwd()
-            if '-a' in args or '--alongside' in args:
-                strategy = CreateAlongsideHookStrategy(hook_path)
-            elif '-o' in args or '--overwrite' in args:
-                strategy = CreateHookStrategy(hook_path)
-            elif not any_hooks_present(hook_path):
-                strategy = CreateHookStrategy(hook_path)
-            else:
-                strategy = PromptUserForHookTypeStrategy(hook_path)
-            return StrategyCommand(strategy)
+        hook_path = git_hook_path_from_cwd()
+        if '-a' in args or '--alongside' in args:
+            strategy = CreateAlongsideHookStrategy(hook_path)
+        elif '-o' in args or '--overwrite' in args:
+            strategy = CreateHookStrategy(hook_path)
+        elif not any_hooks_present(hook_path):
+            strategy = CreateHookStrategy(hook_path)
         else:
-            return StrategyCommand(PrintCommandStrategy('Git not initialized in this directory.'))
+            strategy = PromptUserForHookTypeStrategy(hook_path)
+        return StrategyCommand(strategy)

--- a/guet/main.py
+++ b/guet/main.py
@@ -17,16 +17,26 @@ from guet.commands.config.factory import ConfigCommandFactory, CONFIG_HELP_MESSA
 def _command_builder_map():
     command_builder_map = dict()
     command_builder_map['add'] = InitRequiredDecorator(HelpDecorator(AddCommitterFactory(), ADD_COMMITTER_HELP_MESSAGE))
+
     command_builder_map['init'] = HelpDecorator(InitCommandFactory(), INIT_HELP_MESSAGE, no_args_valid=True)
-    command_builder_map['set'] = InitRequiredDecorator(HelpDecorator(SetCommittersCommandFactory(), SET_HELP_MESSAGE))
+
+    command_builder_map['set'] = InitRequiredDecorator(
+        GitRequiredDecorator(
+            HelpDecorator(SetCommittersCommandFactory(), SET_HELP_MESSAGE)
+        )
+    )
+
     command_builder_map['start'] = InitRequiredDecorator(
         HelpDecorator(
             GitRequiredDecorator(StartCommandFactory()), START_HELP_MESSAGE, no_args_valid=True
         )
     )
     command_builder_map['config'] = InitRequiredDecorator(HelpDecorator(ConfigCommandFactory(), CONFIG_HELP_MESSAGE))
+
     command_builder_map['get'] = InitRequiredDecorator(HelpDecorator(GetCommandFactory(), GET_HELP_MESSAGE))
+
     command_builder_map['remove'] = InitRequiredDecorator(HelpDecorator(RemoveCommandFactory(), REMOVE_HELP_MESSAGE))
+
     return command_builder_map
 
 

--- a/guet/main.py
+++ b/guet/main.py
@@ -1,6 +1,7 @@
 import sys
 
 from guet.commands.get.get_factory import GetCommandFactory, GET_HELP_MESSAGE
+from guet.commands.git_required_decorator import GitRequiredDecorator
 from guet.commands.help_decorator import HelpDecorator
 from guet.commands.init_required_decorator import InitRequiredDecorator
 from guet.commands.remove.factory import RemoveCommandFactory, REMOVE_HELP_MESSAGE
@@ -19,7 +20,10 @@ def _command_builder_map():
     command_builder_map['init'] = HelpDecorator(InitCommandFactory(), INIT_HELP_MESSAGE, no_args_valid=True)
     command_builder_map['set'] = InitRequiredDecorator(HelpDecorator(SetCommittersCommandFactory(), SET_HELP_MESSAGE))
     command_builder_map['start'] = InitRequiredDecorator(
-        HelpDecorator(StartCommandFactory(), START_HELP_MESSAGE, no_args_valid=True))
+        HelpDecorator(
+            GitRequiredDecorator(StartCommandFactory()), START_HELP_MESSAGE, no_args_valid=True
+        )
+    )
     command_builder_map['config'] = InitRequiredDecorator(HelpDecorator(ConfigCommandFactory(), CONFIG_HELP_MESSAGE))
     command_builder_map['get'] = InitRequiredDecorator(HelpDecorator(GetCommandFactory(), GET_HELP_MESSAGE))
     command_builder_map['remove'] = InitRequiredDecorator(HelpDecorator(RemoveCommandFactory(), REMOVE_HELP_MESSAGE))

--- a/test/commands/start/test_factory.py
+++ b/test/commands/start/test_factory.py
@@ -2,20 +2,10 @@ import unittest
 from unittest.mock import Mock, patch, call
 
 from guet.commands.start.factory import StartCommandFactory
-from guet.git.create_hook import HookMode, Hooks
 from guet.settings.settings import Settings
 
 
 class TestStartCommandFactoryMethod(unittest.TestCase):
-    @patch('guet.commands.start.factory.PrintCommandStrategy')
-    @patch('guet.commands.start.factory.StrategyCommand')
-    @patch('guet.commands.start.factory.git_present_in_cwd', return_value=False)
-    def test_returns_print_strategy_with_error_message_if_no_git_present(self, _, mock_strategy_command,
-                                                                         mock_print_strategy):
-        command = StartCommandFactory().build(['start'], Settings())
-        mock_print_strategy.assert_called_with('Git not initialized in this directory.')
-        mock_strategy_command.assert_called_with(mock_print_strategy.return_value)
-        self.assertEqual(command, mock_strategy_command.return_value)
 
     @patch('guet.commands.start.factory.any_hooks_present', return_value=True)
     @patch('guet.commands.start.factory.git_hook_path_from_cwd', return_value='/path')

--- a/test/commands/test_git_required_decorator.py
+++ b/test/commands/test_git_required_decorator.py
@@ -1,0 +1,45 @@
+from unittest import TestCase
+from unittest.mock import Mock, patch
+
+from guet.commands.git_required_decorator import GitRequiredDecorator
+from guet.commands.print_strategy import PrintCommandStrategy
+from guet.settings.settings import Settings
+
+
+@patch('guet.commands.git_required_decorator.git_present_in_cwd', return_value=True)
+class TestGitRequiredDecorator(TestCase):
+
+    def test_returns_decorated_factory_build(self, _):
+        mock_command = Mock()
+        mock_factory = Mock()
+        mock_factory.build.return_value = mock_command
+
+        decorator = GitRequiredDecorator(mock_factory)
+
+        result = decorator.build([], Settings())
+        self.assertEqual(mock_command, result)
+
+    def test_does_not_build_decorated_factory_when_git_not_present_in_cwd(self, mock_git_present_in_cwd):
+        mock_git_present_in_cwd.return_value = False
+
+        mock_command = Mock()
+        mock_factory = Mock()
+        mock_factory.build.return_value = mock_command
+
+        decorator = GitRequiredDecorator(mock_factory)
+
+        decorator.build([], Settings())
+        mock_factory.build.assert_not_called()
+
+    def test_returns_command_with_print_strategy_that_says_git_not_present_in_cwd(self, mock_git_present_in_cwd):
+        mock_git_present_in_cwd.return_value = False
+
+        mock_command = Mock()
+        mock_factory = Mock()
+        mock_factory.build.return_value = mock_command
+
+        decorator = GitRequiredDecorator(mock_factory)
+
+        result = decorator.build([], Settings())
+        self.assertIsInstance(result.strategy, PrintCommandStrategy)
+        self.assertEqual(result.strategy._text, 'Git not initialized in this directory.')


### PR DESCRIPTION
## Overview
Blocks running `guet set` in a folder that doesn't contain a git project.

Connects #37 

### Demo
```
$ cd project
$ guet set cb aw
Git not initialized in this directory.
```

### Notes
This error message is fine, but doesn't quite get at the route of the problem. A `guet start` is required for a `guet set` to be valuable. However, I'm am unconvinced that not having ran `guet start` should stop the user from setting the committers. It should, at the very least, warn you that you haven't started this repo for use with guet.