### PR TITLE
Fix bug where stacktrace prints malformed in errors file

### DIFF
--- a/e2e/test_errors.py
+++ b/e2e/test_errors.py
@@ -1,0 +1,13 @@
+from e2e import DockerTest
+
+
+class TestError(DockerTest):
+
+    def test_uncaught_errors_are_written_to_log_file(self):
+        self.guet_init()
+        self.add_command('guet notacommand')
+        self.save_file_content('.guet/errors')
+
+        self.execute()
+
+        self.assertEqual(self.get_file_text('.guet/errors')[0], 'Traceback (most recent call last):')

--- a/guet/util/errors.py
+++ b/guet/util/errors.py
@@ -10,8 +10,8 @@ def log_on_error(wrapped):
         # pylint: disable=broad-except
         except Exception:
             print('An error has occurred, please refer to error logs for more information\n')
-            stack_tract = traceback.format_exc()
-            set_errors(stack_tract)
+            stack_tract: str = traceback.format_exc()
+            set_errors(stack_tract.split('\n'))
             exit(1)
 
     return wrapper

--- a/test/util/test_errors.py
+++ b/test/util/test_errors.py
@@ -18,13 +18,11 @@ class TestErrorWrapper(unittest.TestCase):
         def func():
             raise ValueError
 
-        mock_format_exc.return_value = [
-            'line1\n'
-        ]
+        mock_format_exc.return_value = 'line1\nline2'
 
         func()
 
-        mock_set_errors.assert_called_with(['line1\n'])
+        mock_set_errors.assert_called_with(['line1', 'line2'])
 
     def test_says_an_error_occurred(self,
                                     mock_format_exc,
@@ -35,26 +33,22 @@ class TestErrorWrapper(unittest.TestCase):
         def func():
             raise ValueError
 
-        mock_format_exc.return_value = [
-            'line1\n'
-        ]
+        mock_format_exc.return_value = 'line1\nline2'
 
         func()
 
         mock_print.assert_called_with('An error has occurred, please refer to error logs for more information\n')
 
     def test_exits_one_on_error(self,
-                                    mock_format_exc,
-                                    mock_set_errors,
-                                    mock_print,
-                                    mock_exit):
+                                mock_format_exc,
+                                mock_set_errors,
+                                mock_print,
+                                mock_exit):
         @log_on_error
         def func():
             raise ValueError
 
-        mock_format_exc.return_value = [
-            'line1\n'
-        ]
+        mock_format_exc.return_value = 'line1'
 
         func()
 


### PR DESCRIPTION
## Overview
Corrects error where every character in written to `.guet/errors` had a newline character appended to it.

Connects #42

### Demo
```
$ guet command    # something that causes an error
An error has occurred, please refer to error logs for more information
$ cat ~/.guet/errors
Traceback (most recent call last):
...
```

### Notes
The end-to-end test for this bug will fail if #33 is introduced. This is because at the time of implementation the easiest way to trigger a failure is to try and execute a command that guet cannot process (`guet fail`).