### PR TITLE
Include path to the error file in the error message

### DIFF
--- a/guet/util/errors.py
+++ b/guet/util/errors.py
@@ -9,7 +9,7 @@ def log_on_error(wrapped):
             wrapped()
         # pylint: disable=broad-except
         except Exception:
-            print('An error has occurred, please refer to error logs for more information\n')
+            print('An error has occurred, please refer to error logs (~/.guet/errors) for more information\n')
             stack_tract: str = traceback.format_exc()
             set_errors(stack_tract.split('\n'))
             exit(1)

--- a/test/util/test_errors.py
+++ b/test/util/test_errors.py
@@ -37,7 +37,7 @@ class TestErrorWrapper(unittest.TestCase):
 
         func()
 
-        mock_print.assert_called_with('An error has occurred, please refer to error logs for more information\n')
+        mock_print.assert_called_with('An error has occurred, please refer to error logs (~/.guet/errors) for more information\n')
 
     def test_exits_one_on_error(self,
                                 mock_format_exc,


### PR DESCRIPTION
## Overview
Brief description of what this PR does, and why it is needed.

Connects #31 

### Demo
Example of pull request in use in the following format:
```
$ guet invalid-command
An error has occurred, please refer to error logs (~/.guet/errors) for more information.
```
