### PR TITLE
Dont overwrite committers without warning

### DIFF
--- a/e2e/dockertest/docker_test.py
+++ b/e2e/dockertest/docker_test.py
@@ -82,8 +82,11 @@ class DockerTest(unittest.TestCase):
         self.add_command(command)
 
     @_called_execute
-    def guet_add(self, initials: str, name: str, email: str):
-        self.add_command(f'guet add {initials} "{name}" {email}')
+    def guet_add(self, initials: str, name: str, email: str, *, overwrite_answer=None):
+        command = f'guet add {initials} "{name}" {email}'
+        if overwrite_answer:
+            command = f'printf {overwrite_answer} | {command}'
+        self.add_command(command)
 
     @_called_execute
     def guet_remove(self, initials: str):

--- a/e2e/test_addcommitter.py
+++ b/e2e/test_addcommitter.py
@@ -30,3 +30,17 @@ class TestAddUser(DockerTest):
 
         committers_file = self.get_file_text('.guet/committers')
         self.assertEqual('initials,name,email', committers_file[0])
+
+    def test_prompts_user_to_overwrite_committers_when_given_same_initials(self):
+        self.guet_init()
+        self.guet_add('initials', 'name1', 'email1')
+        self.guet_add('initials', 'name2', 'email2', overwrite_answer='y')
+        self.guet_get_committers()
+        self.guet_add('initials', 'name1', 'email1', overwrite_answer='x')
+        self.guet_get_committers()
+        self.execute()
+        self.assert_text_in_logs(0, ('Matching initials "initials". Adding "name2" <email2> '
+                                     'will overwrite "name1" <email1>. Would you '
+                                     'like to continue (y) or cancel (x)?'))
+        self.assert_text_in_logs(2, 'initials - name2 <email2>')
+        self.assert_text_in_logs(5, 'initials - name2 <email2>')

--- a/guet/commands/addcommitter/factory.py
+++ b/guet/commands/addcommitter/factory.py
@@ -1,7 +1,10 @@
 from typing import List
 
+from guet.commands.cancellable_strategy import CancelableCommandStrategy
 from guet.commands.command import Command
+from guet.commands.do_nothing_strategy import DoNothingStrategy
 from guet.commands.help.help_message_builder import HelpMessageBuilder
+from guet.config.get_committers import get_committers
 from guet.settings.settings import Settings
 from guet.commands.command_factory import CommandFactoryMethod
 from guet.commands.strategy_command import StrategyCommand
@@ -23,10 +26,27 @@ class AddCommitterFactory(CommandFactoryMethod):
     def short_help_message(self):
         return 'Add committer to the list of available committers'
 
+    def _initials_already_present(self, initials):
+        return len([committer for committer in get_committers() if committer.initials == initials]) != 0
+
+    def _prompt(self, new_initials: str, new_name: str, new_email: str) -> str:
+        matching_committer = next((committer for committer in get_committers() if committer.initials == new_initials))
+        warning = (f'Matching initials "{new_initials}". Adding "{new_name}" <{new_email}> '
+                   f'will overwrite "{matching_committer.name}" <{matching_committer.email}>. Would you '
+                   f'like to continue (y) or cancel (x)?')
+        return warning
+
     def _choose_strategy(self, args: List[str], _: Settings) -> CommandStrategy:
         if len(args) < 3:
             return TooFewArgsStrategy(ADD_COMMITTER_HELP_MESSAGE)
         elif len(args) > 3:
             return TooManyArgsStrategy()
         else:
-            return AddCommitterStrategy(args[0], args[1], args[2])
+            initials, name, email = args
+            add_committers_strategy = AddCommitterStrategy(initials, name, email)
+            if self._initials_already_present(initials):
+                return CancelableCommandStrategy(self._prompt(initials, name, email),
+                                                 add_committers_strategy,
+                                                 DoNothingStrategy())
+            else:
+                return add_committers_strategy

--- a/guet/commands/cancellable_strategy.py
+++ b/guet/commands/cancellable_strategy.py
@@ -1,0 +1,18 @@
+from guet.commands.strategy import CommandStrategy
+
+
+class CancelableCommandStrategy(CommandStrategy):
+    def __init__(self, prompt: str, success_callback: CommandStrategy, cancel_callback: CommandStrategy):
+        self.prompt = prompt
+        self.success_callback = success_callback
+        self.cancel_callback = cancel_callback
+
+    def apply(self):
+        print(self.prompt)
+        answer = input()
+        if answer == 'y':
+            self.success_callback.apply()
+        else:
+            if answer != 'x':
+                print('Given input invalid. Cancelling command.')
+            self.cancel_callback.apply()

--- a/test/commands/addcommitter/test_factory.py
+++ b/test/commands/addcommitter/test_factory.py
@@ -1,0 +1,17 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+from guet.commands.addcommitter.factory import AddCommitterFactory
+from guet.commands.cancellable_strategy import CancelableCommandStrategy
+from guet.config.committer import Committer
+from guet.settings.settings import Settings
+
+
+@patch('guet.commands.addcommitter.factory.get_committers')
+class TestAddCommitterFactory(TestCase):
+
+    def test_returns_cancelable_strategy_if_given_initials_match_already_present_committer(self, get_committers):
+        get_committers.return_value = [Committer(initials='initials', name='name', email='email')]
+        subject = AddCommitterFactory()
+        response = subject.build(['add', 'initials', 'name', 'email'], Settings())
+        self.assertIsInstance(response.strategy, CancelableCommandStrategy)

--- a/test/commands/test_addcommitter.py
+++ b/test/commands/test_addcommitter.py
@@ -5,11 +5,12 @@ from guet.commands.addcommitter.factory import AddCommitterFactory, ADD_COMMITTE
 from guet.settings.settings import Settings
 
 
+@patch('guet.commands.addcommitter.factory.get_committers', return_value=[])
 @patch('guet.commands.addcommitter.add_committer_strategy.add_committer')
 @patch('builtins.print')
 class TestAddUserCommand(unittest.TestCase):
     def test_execute_prints_error_message_when_too_many_arguments_are_given(
-            self, mock_print, mock_add_commiter):
+            self, mock_print, mock_add_commiter, mock_get_committers):
         initials = 'usr'
         name = 'user'
         email = 'user@localhost'
@@ -20,7 +21,7 @@ class TestAddUserCommand(unittest.TestCase):
         mock_print.assert_called_once_with('Too many arguments.')
 
     def test_execute_prints_the_error_message_and_help_message_when_there_are_not_enough_args(
-            self, mock_print, mock_add_commiter):
+            self, mock_print, mock_add_commiter, mock_get_committers):
         command = AddCommitterFactory().build(['guet', 'initials', 'name'], Settings())
         command.execute()
 
@@ -31,11 +32,11 @@ class TestAddUserCommand(unittest.TestCase):
         ]
         mock_print.assert_has_calls(calls)
 
-    def test_get_short_help_message(self, mock_print, mock_add_commiter):
+    def test_get_short_help_message(self, mock_print, mock_add_commiter, mock_get_committers):
         self.assertEqual('Add committer to the list of available committers',
                          AddCommitterFactory().short_help_message())
 
-    def test_execute_also_adds_committer_to_committers_file(self, mock_print, mock_add_commiter):
+    def test_execute_also_adds_committer_to_committers_file(self, mock_print, mock_add_commiter, mock_get_committers):
         command = AddCommitterFactory().build(['add', 'initials', 'name', 'email'], Settings())
         command.execute()
 

--- a/test/commands/test_cancellable_strategy.py
+++ b/test/commands/test_cancellable_strategy.py
@@ -1,0 +1,50 @@
+from unittest import TestCase
+from unittest.mock import patch, Mock, call
+
+from guet.commands.cancellable_strategy import CancelableCommandStrategy
+
+warning = 'warning'
+
+
+@patch('builtins.print')
+@patch('builtins.input', return_value='y')
+class TestCancellableCommandStrategy(TestCase):
+
+    def test_warning_printed(self, _, mock_print):
+        strategy = CancelableCommandStrategy(warning, Mock(), Mock())
+        strategy.apply()
+        mock_print.assert_called_with(warning)
+
+    def test_asks_user_for_input(self, mock_input, _):
+        strategy = CancelableCommandStrategy(warning, Mock(), Mock())
+        strategy.apply()
+        mock_input.assert_called()
+
+    def test_calls_success_callback_if_given_y(self, mock_input, _):
+        mock_input.return_value = 'y'
+        success_callback = Mock()
+        strategy = CancelableCommandStrategy(warning, success_callback, Mock())
+        strategy.apply()
+        success_callback.apply.assert_called()
+
+    def test_calls_cancel_callback_if_given_x(self, mock_input, _):
+        mock_input.return_value = 'x'
+        cancel_callback = Mock()
+        strategy = CancelableCommandStrategy(warning, Mock(), cancel_callback)
+        strategy.apply()
+        cancel_callback.apply.assert_called()
+
+    def test_giving_invalid_input_cancels_request_and_tells_user_they_gave_invalid_input(self, mock_input, mock_print):
+        mock_input.return_value = 'other characters'
+        cancel_callback = Mock()
+        strategy = CancelableCommandStrategy(warning, Mock(), cancel_callback)
+        strategy.apply()
+        mock_print.assert_called_with('Given input invalid. Cancelling command.')
+        cancel_callback.apply.assert_called()
+
+    def test_giving_x_does_not_print_invalid_input_warning(self, mock_input, mock_print):
+        mock_input.return_value = 'x'
+        cancel_callback = Mock()
+        strategy = CancelableCommandStrategy(warning, Mock(), cancel_callback)
+        strategy.apply()
+        mock_print.assert_called_with(warning)


### PR DESCRIPTION
## Overview
When adding a new committer with the same initials as an already present committer, prompt the user if they want to overwrite it.

Connects #32

### Demo
```
$ guet add initials "name1" name1@localhost
$ guet add initials "name2" name2@localhost
Matching initials "initials". Adding "name2" <name2@localhost> will
overwrite "name1" <name1@localhost>. Would you like to
continue (y) or cancel (x)?
y
$ guet get committers
All committers
initials - name2 <name2@email.com>
```