### PR TITLE
Fix error where guet couldn't handle malformed committersset files

### DIFF
--- a/e2e/test_commit.py
+++ b/e2e/test_commit.py
@@ -95,3 +95,21 @@ class TestCommit(DockerTest):
 
         self.assert_text_in_logs(11, '    Co-authored-by: name <email@localhost>')
         self.assert_text_in_logs(12, '    Co-authored-by: name2 <email2@localhost>')
+
+    def test_handles_old_version_of_committersset_string(self):
+        self.guet_init()
+        self.add_file('~/.guet/committersset', 'n1,n2,1581036719234')
+        self.guet_add('initials', 'name', 'email@localhost')
+        self.guet_add('initials2', 'name2', 'email2@localhost')
+        self.git_init()
+        self.guet_start()
+        self.guet_set(['initials', 'initials2'])
+        self.add_file('A')
+        self.git_add()
+        self.git_commit('Initial commit')
+        self.show_git_log()
+
+        self.execute()
+
+        self.assert_text_in_logs(10, '    Co-authored-by: name <email@localhost>')
+        self.assert_text_in_logs(11, '    Co-authored-by: name2 <email2@localhost>')

--- a/guet/config/errors.py
+++ b/guet/config/errors.py
@@ -1,0 +1,2 @@
+class PairSetError(Exception):
+    pass

--- a/guet/config/most_recent_committers_set.py
+++ b/guet/config/most_recent_committers_set.py
@@ -2,12 +2,18 @@ from os.path import join
 
 from guet import constants
 from guet.config import CONFIGURATION_DIRECTORY
+from guet.config.errors import PairSetError
 from guet.files.read_lines import read_lines
 from guet.config.parse_comitters_set_line import parse_committers_set_line
+from guet.git.git_path_from_cwd import git_path_from_cwd
 
 
 def most_recent_committers_set():
     path = join(CONFIGURATION_DIRECTORY, constants.COMMITTERS_SET)
     lines = read_lines(path)
-    *committer_initials, set_time, path_to_git = parse_committers_set_line(lines[0])
-    return int(set_time)
+    try:
+        line = next(line for line in lines if line.endswith(git_path_from_cwd()))
+        *committer_initials, set_time, path_to_git = parse_committers_set_line(line)
+        return int(set_time)
+    except StopIteration:
+        raise PairSetError()

--- a/guet/hooks/pre_commit.py
+++ b/guet/hooks/pre_commit.py
@@ -1,3 +1,4 @@
+from guet.config.errors import PairSetError
 from guet.config.get_config import get_config
 from guet.config.get_current_committers import get_current_committers
 from guet.config.most_recent_committers_set import most_recent_committers_set
@@ -23,8 +24,11 @@ def _fail_if_past_valid_timeframe():
     now = current_millis()
     twenty_four_hours = 86400000
     twenty_four_hours_ago = now - twenty_four_hours
-    set_time = most_recent_committers_set()
-    if set_time < twenty_four_hours_ago:
-        print(("\nYou have not reset pairs in over twenty four hours!\n" +
-               "Please reset your pairs by using guet set and including your pairs' initials\n"))
-        exit(1)
+    try:
+        set_time = most_recent_committers_set()
+        if set_time < twenty_four_hours_ago:
+            print(("\nYou have not reset pairs in over twenty four hours!\n" +
+                   "Please reset your pairs by using guet set and including your pairs' initials\n"))
+            exit(1)
+    except PairSetError:
+        _fail_because_there_are_no_current_committers()

--- a/test/config/test_most_recent_committers_set.py
+++ b/test/config/test_most_recent_committers_set.py
@@ -2,13 +2,26 @@ import unittest
 from unittest.mock import patch, mock_open
 
 from guet.config.most_recent_committers_set import most_recent_committers_set
+from guet.config.errors import PairSetError
 
 
+@patch('guet.config.most_recent_committers_set.git_path_from_cwd', return_value='/path/to/.git')
 @patch('guet.config.most_recent_committers_set.read_lines')
 class TestMostRecentCommittersSet(unittest.TestCase):
 
     def test_gets_the_timestamp_from_committers_set(self,
-                                                    mock_read_lines):
-        mock_read_lines.return_value = ['initials1,initials2,1000000000,/absolute/path/to/.git']
+                                                    mock_read_lines,
+                                                    mock_git_cwd):
+        mock_read_lines.return_value = ['initials1,initials2,1000000000,/path/to/.git']
         result = most_recent_committers_set()
         self.assertEqual(1000000000, result)
+
+    def test_raises_exception_when_no_committersset_have_path_to_git(self,
+                                                                     mock_read_lines,
+                                                                     mock_git_cwd):
+        mock_read_lines.return_value = ['initials1,initials2,1000000000']
+        try:
+            result = most_recent_committers_set()
+            self.fail(f'Should raise {PairSetError.__name__}')
+        except PairSetError:
+            pass

--- a/test/hooks/test_pre_commit.py
+++ b/test/hooks/test_pre_commit.py
@@ -3,6 +3,7 @@ import unittest
 from unittest.mock import patch
 
 from guet.config.committer import Committer
+from guet.config.errors import PairSetError
 from guet.currentmillis import current_millis
 from guet.hooks.pre_commit import pre_commit
 from guet.settings.settings import Settings
@@ -52,6 +53,14 @@ class TestPreCommit(unittest.TestCase):
     def test_wont_allow_commit_if_no_committers_set(self, mock_exit, mock_print, mock_most_recent_committers_set,
                                                     mock_get_config, mock_current):
         mock_current.return_value = []
+        pre_commit()
+        mock_exit.assert_called_once_with(1)
+        mock_print.assert_called_with('You must set your pairs before you can commit.\n')
+
+    def test_wont_allow_commit_if_invalid_committersset_file(self, mock_exit, mock_print,
+                                                             mock_most_recent_committers_set,
+                                                             mock_get_config, mock_current):
+        mock_most_recent_committers_set.side_effect = PairSetError()
         pre_commit()
         mock_exit.assert_called_once_with(1)
         mock_print.assert_called_with('You must set your pairs before you can commit.\n')


### PR DESCRIPTION
## Overview
Corrects an issue where upgrading from <2.3.0 would cause a breaking change unless you deleted your `committersset` file.

Connects #47 

