### PR TITLE
Fix type in guet get help message

### DIFF
--- a/e2e/test_get.py
+++ b/e2e/test_get.py
@@ -47,4 +47,4 @@ class TestGet(DockerTest):
         self.assert_text_in_logs(2, 'Get currently set information.')
         self.assert_text_in_logs(4, 'Valid Identifier')
         self.assert_text_in_logs(6, '\tcurrent - lists currently set committers')
-        self.assert_text_in_logs(7, '\tcomitters - lists all committers')
+        self.assert_text_in_logs(7, '\tcommitters - lists all committers')

--- a/guet/commands/get/get_factory.py
+++ b/guet/commands/get/get_factory.py
@@ -22,7 +22,9 @@ def print_only_initials(committers: List[Committer]) -> None:
 
 
 GET_HELP_MESSAGE = HelpMessageBuilder('guet get <identifier> [-flag, ...]', 'Get currently set information.') \
-    .explanation('Valid Identifier\n\n\tcurrent - lists currently set committers\n\tcommitters - lists all committers') \
+    .explanation(('Valid Identifier'
+                  '\n\n\tcurrent - lists currently set committers'
+                  '\n\tcommitters - lists all committers')) \
     .flags(FlagsBuilder([FlagBuilder('l', 'Print values as truncated list')])).build()
 
 

--- a/guet/commands/get/get_factory.py
+++ b/guet/commands/get/get_factory.py
@@ -22,7 +22,7 @@ def print_only_initials(committers: List[Committer]) -> None:
 
 
 GET_HELP_MESSAGE = HelpMessageBuilder('guet get <identifier> [-flag, ...]', 'Get currently set information.') \
-    .explanation('Valid Identifier\n\n\tcurrent - lists currently set committers\n\tcomitters - lists all committers') \
+    .explanation('Valid Identifier\n\n\tcurrent - lists currently set committers\n\committers - lists all committers') \
     .flags(FlagsBuilder([FlagBuilder('l', 'Print values as truncated list')])).build()
 
 

--- a/guet/commands/get/get_factory.py
+++ b/guet/commands/get/get_factory.py
@@ -22,7 +22,7 @@ def print_only_initials(committers: List[Committer]) -> None:
 
 
 GET_HELP_MESSAGE = HelpMessageBuilder('guet get <identifier> [-flag, ...]', 'Get currently set information.') \
-    .explanation('Valid Identifier\n\n\tcurrent - lists currently set committers\n\committers - lists all committers') \
+    .explanation('Valid Identifier\n\n\tcurrent - lists currently set committers\n\tcommitters - lists all committers') \
     .flags(FlagsBuilder([FlagBuilder('l', 'Print values as truncated list')])).build()
 
 


### PR DESCRIPTION
## Overview
Fixes a typo in the `guet get` help message.

Connects #63 
