### PR TITLE
Don't add a 'Co-authored' line if there is only one committer

### DIFF
--- a/e2e/test_commit.py
+++ b/e2e/test_commit.py
@@ -19,6 +19,20 @@ class TestCommit(DockerTest):
         self.assert_text_in_logs(10, '    Co-authored-by: name <email@localhost>')
         self.assert_text_in_logs(11, '    Co-authored-by: name2 <email2@localhost>')
 
+    def test_if_only_one_committer_set_no_co_authored_by_lines_are_added(self):
+        self.guet_init()
+        self.guet_add('initials', 'name', 'email@localhost')
+        self.git_init()
+        self.guet_start()
+        self.guet_set(['initials'])
+        self.add_file('A')
+        self.git_add()
+        self.git_commit('Initial commit')
+        self.show_git_log()
+
+        self.execute()
+        self.assertEqual(10, len(self.logs))
+
     def test_replaces_co_authored_messages_when_editing_commit(self):
         self.guet_init()
         self.guet_add('initials', 'name', 'email@localhost')

--- a/guet/hooks/commit_msg.py
+++ b/guet/hooks/commit_msg.py
@@ -32,7 +32,8 @@ def commit_msg():
     git = Git(git_path)
     commit_message = git.commit_msg
     current_committers = get_current_committers()
-    co_authored_lines = [_create_co_authored_line(committer) for committer in current_committers]
-    final_commit_message = _replace_already_present_co_authored_messages(
-        commit_message, co_authored_lines)
-    git.commit_msg = final_commit_message
+    if len(current_committers) > 1:
+        co_authored_lines = [_create_co_authored_line(committer) for committer in current_committers]
+        final_commit_message = _replace_already_present_co_authored_messages(
+            commit_message, co_authored_lines)
+        git.commit_msg = final_commit_message

--- a/test/hooks/test_commit_msg.py
+++ b/test/hooks/test_commit_msg.py
@@ -29,6 +29,24 @@ class TestCommitMsg(unittest.TestCase):
         ]
         self.assertListEqual(expected, git.commit_msg)
 
+    def test_doesnt_change_commit_message_if_only_one_committer_is_provided(self,
+                                                                            mock_git,
+                                                                            mock_get_current_committers,
+                                                                            mock_git_path_from_cwd):
+        mock_git_path_from_cwd.return_value = 'path/to/.git'
+        mock_get_current_committers.return_value = [
+            Committer('name1', 'email1', 'initials1'),
+        ]
+        git = mock_git.return_value
+        git.commit_msg = [
+            'Text\n'
+        ]
+        commit_msg()
+        expected = [
+            'Text\n'
+        ]
+        self.assertListEqual(expected, git.commit_msg)
+
     def test_replaces_co_authored_with_new_committers_if_already_present(self,
                                                                          mock_git,
                                                                          mock_get_current_committers,


### PR DESCRIPTION
## Overview
When committing with one committer, the co-authored line will not be added.

### Demo
```
$ git commit -m "add some changes"
$ git log
commit 3887e100b63c0c7f433a579de372338582889263
Author: committer <committer@localhost>
Date:   Sat Mar 14 09:13:14 2020 -0400

    add some changes

```

Before, there would have been a `Co-authored-by: committer <committer@localhost>` following `add some changes`.