### PR TITLE
Add --local flag to guet add

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -17,6 +17,7 @@ max-line-length=120
 # R0903: Too few public methods (0/1) (too-few-public-methods)
 
 max-complexity=5
+max-args=6
 
 disable=R1705,R1722,R0801,C0114,C0116,C0115,R0201,W0108,R0903
 

--- a/e2e/dockertest/docker_test.py
+++ b/e2e/dockertest/docker_test.py
@@ -82,10 +82,12 @@ class DockerTest(unittest.TestCase):
         self.add_command(command)
 
     @_called_execute
-    def guet_add(self, initials: str, name: str, email: str, *, overwrite_answer=None):
+    def guet_add(self, initials: str, name: str, email: str, *, overwrite_answer=None, local=False):
         command = f'guet add {initials} "{name}" {email}'
         if overwrite_answer:
             command = f'printf {overwrite_answer} | {command}'
+        if local:
+            command = f'guet add --local {initials} "{name}" {email}'
         self.add_command(command)
 
     @_called_execute

--- a/e2e/test_addcommitter.py
+++ b/e2e/test_addcommitter.py
@@ -66,3 +66,13 @@ class TestAddUser(DockerTest):
 
         text = self.get_file_text('test-env/.guet/committers')
         self.assertListEqual(['initials2,name2,email2'], text)
+
+    def test_prints_error_message_when_adding_local_committer_that_has_same_initials_as_global_committer(self):
+        self.guet_init()
+        self.guet_add('initials', 'name1', 'email1')
+        self.guet_add('initials', 'name2', 'emial2', local=True)
+
+        self.execute()
+
+        self.assert_text_in_logs(0, ('Adding committer with initials "initials" shadows the '
+                                     'global committer "initials" - "name1" <email1>'))

--- a/e2e/test_addcommitter.py
+++ b/e2e/test_addcommitter.py
@@ -45,3 +45,13 @@ class TestAddUser(DockerTest):
                                      'like to continue (y) or cancel (x)?'))
         self.assert_text_in_logs(2, 'initials - name2 <email2>')
         self.assert_text_in_logs(5, 'initials - name2 <email2>')
+
+    def test_including_local_flag_adds_committer_to_the_repository(self):
+        self.guet_init()
+        self.guet_add('initials', 'name1', 'email1', local=True)
+        self.save_file_content('test-env/.guet/committers')
+
+        self.execute()
+
+        text = self.get_file_text('test-env/.guet/committers')
+        self.assertListEqual(['initials,name1,email1'], text)

--- a/e2e/test_addcommitter.py
+++ b/e2e/test_addcommitter.py
@@ -55,3 +55,14 @@ class TestAddUser(DockerTest):
 
         text = self.get_file_text('test-env/.guet/committers')
         self.assertListEqual(['initials,name1,email1'], text)
+
+    def test_adding_local_committers_only_saves_the_local_committers(self):
+        self.guet_init()
+        self.guet_add('initials1', 'name1', 'email1')
+        self.guet_add('initials2', 'name2', 'email2', local=True)
+        self.save_file_content('test-env/.guet/committers')
+
+        self.execute()
+
+        text = self.get_file_text('test-env/.guet/committers')
+        self.assertListEqual(['initials2,name2,email2'], text)

--- a/guet/commands/addcommitter/add_committer_locally_strategy.py
+++ b/guet/commands/addcommitter/add_committer_locally_strategy.py
@@ -1,6 +1,26 @@
+from os import mkdir
+from os.path import isdir, join
+
 from guet.commands.strategy import CommandStrategy
+from guet.committers.local_committer import LocalCommitter
+from guet.config.committers import Committers
 
 
 class AddCommitterLocallyStrategy(CommandStrategy):
+    def __init__(self, initials: str, name: str, email: str, project_root: str, committers: Committers):
+        self._initials = initials
+        self._name = name
+        self._email = email
+        self._project_root = project_root
+        self._committers = committers
+
     def apply(self) -> None:
-        pass
+        self._create_local_guet_folder_if_not_exists()
+        committer = LocalCommitter(name=self._name, email=self._email, initials=self._initials,
+                                   project_root=self._project_root)
+        self._committers.add(committer)
+
+    def _create_local_guet_folder_if_not_exists(self) -> None:
+        folder_path = join(self._project_root, '.guet')
+        if not isdir(folder_path):
+            mkdir(folder_path)

--- a/guet/commands/addcommitter/add_committer_locally_strategy.py
+++ b/guet/commands/addcommitter/add_committer_locally_strategy.py
@@ -1,0 +1,6 @@
+from guet.commands.strategy import CommandStrategy
+
+
+class AddCommitterLocallyStrategy(CommandStrategy):
+    def apply(self) -> None:
+        pass

--- a/guet/commands/addcommitter/add_committer_strategy.py
+++ b/guet/commands/addcommitter/add_committer_strategy.py
@@ -1,9 +1,9 @@
 from guet.commands.strategy import CommandStrategy
-from guet.config.committer import Committer
+from guet.committers.global_committer import GlobalCommitter
 from guet.config.committers import Committers
 
 
-class AddCommitterStrategy(CommandStrategy):
+class AddCommitterGloballyStrategy(CommandStrategy):
     def __init__(self, initials: str, name: str, email: str, committers: Committers):
         super().__init__()
         self._name = name
@@ -12,4 +12,4 @@ class AddCommitterStrategy(CommandStrategy):
         self._committers = committers
 
     def apply(self):
-        self._committers.add(Committer(name=self._name, email=self._email, initials=self._initials))
+        self._committers.add(GlobalCommitter(name=self._name, email=self._email, initials=self._initials))

--- a/guet/commands/addcommitter/add_committer_strategy.py
+++ b/guet/commands/addcommitter/add_committer_strategy.py
@@ -1,13 +1,15 @@
 from guet.commands.strategy import CommandStrategy
-from guet.config.add_committer import add_committer
+from guet.config.committer import Committer
+from guet.config.committers import Committers
 
 
 class AddCommitterStrategy(CommandStrategy):
-    def __init__(self, initials: str, name: str, email: str):
+    def __init__(self, initials: str, name: str, email: str, committers: Committers):
         super().__init__()
         self._name = name
         self._email = email
         self._initials = initials
+        self._committers = committers
 
     def apply(self):
-        add_committer(self._initials, self._name, self._email)
+        self._committers.add(Committer(name=self._name, email=self._email, initials=self._initials))

--- a/guet/commands/addcommitter/factory.py
+++ b/guet/commands/addcommitter/factory.py
@@ -1,3 +1,4 @@
+from os import getcwd
 from typing import List
 
 from guet.commands.addcommitter.add_committer_locally_strategy import AddCommitterLocallyStrategy
@@ -46,7 +47,9 @@ class AddCommitterFactory(CommandFactoryMethod):
         else:
             initials, name, email = args_without_flag
             if add_locally:
-                add_committers_strategy = AddCommitterLocallyStrategy()
+                add_committers_strategy = AddCommitterLocallyStrategy(initials, name, email,
+                                                                      project_root=getcwd(),
+                                                                      committers=self.context.committers)
             else:
                 add_committers_strategy = AddCommitterGloballyStrategy(initials, name, email, self.context.committers)
             if self._initials_already_present(initials):

--- a/guet/commands/addcommitter/factory.py
+++ b/guet/commands/addcommitter/factory.py
@@ -1,5 +1,6 @@
 from typing import List
 
+from guet.commands.addcommitter.add_committer_locally_strategy import AddCommitterLocallyStrategy
 from guet.commands.addcommitter.add_committer_strategy import AddCommitterStrategy
 from guet.commands.cancellable_strategy import CancelableCommandStrategy
 from guet.commands.command import Command
@@ -36,13 +37,18 @@ class AddCommitterFactory(CommandFactoryMethod):
         return warning
 
     def _choose_strategy(self, args: List[str], _: Settings) -> CommandStrategy:
-        if len(args) < 3:
+        add_locally = '--local' in args
+        args_without_flag = [arg for arg in args if arg != '--local']
+        if len(args_without_flag) < 3:
             return TooFewArgsStrategy(ADD_COMMITTER_HELP_MESSAGE)
-        elif len(args) > 3:
+        elif len(args_without_flag) > 3:
             return TooManyArgsStrategy()
         else:
-            initials, name, email = args
-            add_committers_strategy = AddCommitterStrategy(initials, name, email)
+            initials, name, email = args_without_flag
+            if add_locally:
+                add_committers_strategy = AddCommitterLocallyStrategy()
+            else:
+                add_committers_strategy = AddCommitterStrategy(initials, name, email)
             if self._initials_already_present(initials):
                 return CancelableCommandStrategy(self._prompt(initials, name, email),
                                                  add_committers_strategy,

--- a/guet/commands/addcommitter/factory.py
+++ b/guet/commands/addcommitter/factory.py
@@ -48,7 +48,7 @@ class AddCommitterFactory(CommandFactoryMethod):
             if add_locally:
                 add_committers_strategy = AddCommitterLocallyStrategy()
             else:
-                add_committers_strategy = AddCommitterStrategy(initials, name, email)
+                add_committers_strategy = AddCommitterStrategy(initials, name, email, self.context.committers)
             if self._initials_already_present(initials):
                 return CancelableCommandStrategy(self._prompt(initials, name, email),
                                                  add_committers_strategy,

--- a/guet/commands/addcommitter/factory.py
+++ b/guet/commands/addcommitter/factory.py
@@ -1,7 +1,7 @@
 from typing import List
 
 from guet.commands.addcommitter.add_committer_locally_strategy import AddCommitterLocallyStrategy
-from guet.commands.addcommitter.add_committer_strategy import AddCommitterStrategy
+from guet.commands.addcommitter.add_committer_strategy import AddCommitterGloballyStrategy
 from guet.commands.cancellable_strategy import CancelableCommandStrategy
 from guet.commands.command import Command
 from guet.commands.command_factory import CommandFactoryMethod
@@ -48,7 +48,7 @@ class AddCommitterFactory(CommandFactoryMethod):
             if add_locally:
                 add_committers_strategy = AddCommitterLocallyStrategy()
             else:
-                add_committers_strategy = AddCommitterStrategy(initials, name, email, self.context.committers)
+                add_committers_strategy = AddCommitterGloballyStrategy(initials, name, email, self.context.committers)
             if self._initials_already_present(initials):
                 return CancelableCommandStrategy(self._prompt(initials, name, email),
                                                  add_committers_strategy,

--- a/guet/committers/global_committer.py
+++ b/guet/committers/global_committer.py
@@ -1,0 +1,7 @@
+from guet.config.add_committer import add_committer
+from guet.config.committer import Committer
+
+
+class GlobalCommitter(Committer):
+    def save(self):
+        add_committer(self.initials, self.name, self.email)

--- a/guet/committers/local_committer.py
+++ b/guet/committers/local_committer.py
@@ -1,0 +1,15 @@
+from os.path import join
+
+from guet import constants
+from guet.config.add_committer import add_committer
+from guet.config.committer import Committer
+
+
+class LocalCommitter(Committer):
+    def __init__(self, name: str, email: str, initials: str, project_root: str):
+        super().__init__(name, email, initials)
+        self._project_root = project_root
+
+    def save(self):
+        path = join(self._project_root, '.guet', constants.COMMITTERS)
+        add_committer(self.initials, self.name, self.email, file_path=path)

--- a/guet/config/add_committer.py
+++ b/guet/config/add_committer.py
@@ -6,11 +6,13 @@ from guet.config import CONFIGURATION_DIRECTORY
 
 _COMMITTER_NOT_PRESENT = -1
 
+_GLOBAL = join(CONFIGURATION_DIRECTORY, constants.COMMITTERS)
 
-def add_committer(initials: str, name: str, email: str) -> None:
+
+def add_committer(initials: str, name: str, email: str, *, file_path: str = _GLOBAL) -> None:
     all_committers = _read_all_committers_from_file()
     _add_committer_to_committers(all_committers, initials, name, email)
-    _write_committers_to_file(all_committers)
+    _write_committers_to_file(all_committers, file_path)
 
 
 def _add_committer_to_committers(all_committers: List[str], initials: str, name: str, email: str):
@@ -36,7 +38,7 @@ def _read_all_committers_from_file() -> List[str]:
     return all_lines
 
 
-def _write_committers_to_file(committers: List[str]) -> None:
-    committers_file = open(join(CONFIGURATION_DIRECTORY, constants.COMMITTERS), 'w')
+def _write_committers_to_file(committers: List[str], path: str) -> None:
+    committers_file = open(path, 'w')
     committers_file.writelines(committers)
     committers_file.close()

--- a/guet/config/add_committer.py
+++ b/guet/config/add_committer.py
@@ -10,7 +10,7 @@ _GLOBAL = join(CONFIGURATION_DIRECTORY, constants.COMMITTERS)
 
 
 def add_committer(initials: str, name: str, email: str, *, file_path: str = _GLOBAL) -> None:
-    all_committers = _read_all_committers_from_file()
+    all_committers = _read_all_committers_from_file(file_path)
     _add_committer_to_committers(all_committers, initials, name, email)
     _write_committers_to_file(all_committers, file_path)
 
@@ -31,11 +31,14 @@ def _position_of_committer_with_initials(all_committers: List[str], initials: st
     return _COMMITTER_NOT_PRESENT
 
 
-def _read_all_committers_from_file() -> List[str]:
-    committers_file = open(join(CONFIGURATION_DIRECTORY, constants.COMMITTERS), 'r')
-    all_lines = committers_file.readlines()
-    committers_file.close()
-    return all_lines
+def _read_all_committers_from_file(path) -> List[str]:
+    try:
+        committers_file = open(path, 'r')
+        all_lines = committers_file.readlines()
+        committers_file.close()
+        return all_lines
+    except FileNotFoundError:
+        return []
 
 
 def _write_committers_to_file(committers: List[str], path: str) -> None:

--- a/guet/config/committer.py
+++ b/guet/config/committer.py
@@ -16,6 +16,9 @@ class Committer:
     def pretty(self):
         return f'{self.initials} - {self.name} <{self.email}>'
 
+    def save(self):
+        raise NotImplementedError()
+
 
 def filter_committers_with_initials(committers: List[Committer],
                                     initials: List[str]) -> List[Committer]:

--- a/guet/config/committers.py
+++ b/guet/config/committers.py
@@ -2,6 +2,7 @@ from os.path import join
 from typing import List
 
 from guet import constants
+from guet.committers.global_committer import GlobalCommitter
 from guet.config import CONFIGURATION_DIRECTORY
 from guet.config.add_committer import add_committer
 from guet.config.committer import Committer
@@ -13,12 +14,12 @@ from guet.files.read_lines import read_lines
 from guet.files.write_lines import write_lines
 
 
-def _load_committers(path: str):
+def _load_committers(path: str) -> List[Committer]:
     lines = read_lines(path)
     committers = []
     for line in lines:
         initials, name, email = line.rstrip().split(',')
-        committers.append(Committer(initials=initials, name=name, email=email))
+        committers.append(GlobalCommitter(initials=initials, name=name, email=email))
     return committers
 
 
@@ -55,7 +56,7 @@ class Committers(SetCommitterObserver):
     def add(self, committer: Committer):
         if committer not in self.all():
             self._committers.append(committer)
-            add_committer(committer.initials, committer.name, committer.email)
+            committer.save()
 
     def by_initials(self, initials: str):
         try:

--- a/guet/config/committers.py
+++ b/guet/config/committers.py
@@ -5,7 +5,6 @@ from guet import constants
 from guet.committers.global_committer import GlobalCommitter
 from guet.committers.local_committer import LocalCommitter
 from guet.config import CONFIGURATION_DIRECTORY
-from guet.config.add_committer import add_committer
 from guet.config.committer import Committer
 from guet.config.errors import InvalidInitialsError
 from guet.config.set_author import set_committer_as_author

--- a/guet/context/context.py
+++ b/guet/context/context.py
@@ -34,7 +34,7 @@ class Context(SetCommittersObservable):
 
     def __init__(self, project_root_directory: str):
         super().__init__()
-        self._committers = None
+        self._committers: Committers = None
         self._git = None
         self.project_root_directory = project_root_directory
 

--- a/guet/context/context.py
+++ b/guet/context/context.py
@@ -41,7 +41,7 @@ class Context(SetCommittersObservable):
     @property
     def committers(self):
         if self._committers is None:
-            self._committers = Committers()
+            self._committers = Committers(path_to_project_root=self.project_root_directory)
             self.add_set_committer_observer(self._committers)
         return self._committers
 

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(name='guet',
       packages=[
           'guet',
           'guet.commands',
+          'guet.committers',
           'guet.commands.get',
           'guet.commands.addcommitter',
           'guet.commands.init',

--- a/test/commands/addcommitter/test_add_committer_local_strategy.py
+++ b/test/commands/addcommitter/test_add_committer_local_strategy.py
@@ -1,0 +1,27 @@
+from os.path import join
+from unittest import TestCase
+from unittest.mock import Mock, patch
+
+from guet.commands.addcommitter.add_committer_locally_strategy import AddCommitterLocallyStrategy
+from guet.committers.local_committer import LocalCommitter
+from guet.config.committers import Committers
+
+
+@patch('guet.commands.addcommitter.add_committer_locally_strategy.mkdir', return_value=True)
+@patch('guet.commands.addcommitter.add_committer_locally_strategy.isdir', return_value=True)
+class TestAddLocalCommitterStrategy(TestCase):
+    def test_apply_adds_committer_to_committers(self, mock_isdir, mock_mkdir):
+        committers: Committers = Mock()
+        strategy = AddCommitterLocallyStrategy('initials', 'name', 'email', '/path/to/root', committers)
+        strategy.apply()
+
+        expected = LocalCommitter(name='name', email='email', initials='initials', project_root='/path/to/root')
+        committers.add.assert_called_with(expected)
+
+    def test_apply_creates_a_guet_directory_at_project_root_if_one_does_not_exist_already(self, mock_isdir, mock_mkdir):
+        mock_isdir.return_value = False
+        committers: Committers = Mock()
+        strategy = AddCommitterLocallyStrategy('initials', 'name', 'email', '/path/to/root', committers)
+        strategy.apply()
+
+        mock_mkdir.assert_called_with(join('/path/to/root', '.guet'))

--- a/test/commands/addcommitter/test_add_committer_strategy.py
+++ b/test/commands/addcommitter/test_add_committer_strategy.py
@@ -1,0 +1,16 @@
+from unittest import TestCase
+from unittest.mock import Mock
+
+from guet.commands.addcommitter.add_committer_strategy import AddCommitterStrategy
+from guet.config.committer import Committer
+from guet.config.committers import Committers
+
+
+class TestAddCommitterStrategy(TestCase):
+    def test_apply_adds_committers(self):
+        committers: Committers = Mock()
+        strategy = AddCommitterStrategy('initials', 'name', 'email', committers)
+
+        strategy.apply()
+
+        committers.add.assert_called_with(Committer(initials='initials', name='name', email='email'))

--- a/test/commands/addcommitter/test_add_committer_strategy.py
+++ b/test/commands/addcommitter/test_add_committer_strategy.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 from unittest.mock import Mock
 
-from guet.commands.addcommitter.add_committer_strategy import AddCommitterStrategy
+from guet.commands.addcommitter.add_committer_strategy import AddCommitterGloballyStrategy
 from guet.config.committer import Committer
 from guet.config.committers import Committers
 
@@ -9,7 +9,7 @@ from guet.config.committers import Committers
 class TestAddCommitterStrategy(TestCase):
     def test_apply_adds_committers(self):
         committers: Committers = Mock()
-        strategy = AddCommitterStrategy('initials', 'name', 'email', committers)
+        strategy = AddCommitterGloballyStrategy('initials', 'name', 'email', committers)
 
         strategy.apply()
 

--- a/test/commands/addcommitter/test_factory.py
+++ b/test/commands/addcommitter/test_factory.py
@@ -1,8 +1,10 @@
 from unittest import TestCase
 from unittest.mock import patch, call, Mock
 
+from guet.commands.addcommitter.add_committer_locally_strategy import AddCommitterLocallyStrategy
 from guet.commands.addcommitter.factory import AddCommitterFactory, ADD_COMMITTER_HELP_MESSAGE
 from guet.commands.cancellable_strategy import CancelableCommandStrategy
+from guet.commands.too_many_args import TooManyArgsStrategy
 from guet.config.committer import Committer
 from guet.context.context import Context
 from guet.settings.settings import Settings
@@ -58,3 +60,14 @@ class TestAddCommitterFactory(TestCase):
         command.execute()
 
         mock_add_commiter.assert_called_with('initials', 'name', 'email')
+
+
+class TestBuildLocal(TestCase):
+
+    def test_uses_add_local_strategy_when_given_local_flag(self):
+        initials = 'initials'
+        name = 'name'
+        email = 'email'
+        command = AddCommitterFactory().build(['add', '--local', initials, name, email], Settings())
+        command.execute()
+        self.assertIsInstance(command.strategy, AddCommitterLocallyStrategy)

--- a/test/commands/addcommitter/test_factory.py
+++ b/test/commands/addcommitter/test_factory.py
@@ -4,19 +4,16 @@ from unittest.mock import patch, call, Mock
 from guet.commands.addcommitter.add_committer_locally_strategy import AddCommitterLocallyStrategy
 from guet.commands.addcommitter.factory import AddCommitterFactory, ADD_COMMITTER_HELP_MESSAGE
 from guet.commands.cancellable_strategy import CancelableCommandStrategy
-from guet.commands.too_many_args import TooManyArgsStrategy
 from guet.config.committer import Committer
 from guet.context.context import Context
 from guet.settings.settings import Settings
 
 
 @patch('guet.commands.command_factory.Context')
-@patch('guet.commands.addcommitter.add_committer_strategy.add_committer')
 @patch('builtins.print')
 class TestAddCommitterFactory(TestCase):
 
     def test_returns_cancelable_strategy_if_given_initials_match_already_present_committer(self, mock_print,
-                                                                                           mock_add_committer,
                                                                                            mock_context):
         mock_committers = Mock()
         context: Context = mock_context.instance.return_value
@@ -27,7 +24,7 @@ class TestAddCommitterFactory(TestCase):
         response = subject.build(['add', 'initials', 'name', 'email'], Settings())
         self.assertIsInstance(response.strategy, CancelableCommandStrategy)
 
-    def test_execute_prints_error_message_when_too_many_arguments_are_given(self, mock_print, mock_add_commiter,
+    def test_execute_prints_error_message_when_too_many_arguments_are_given(self, mock_print,
                                                                             mock_context):
         initials = 'usr'
         name = 'user'
@@ -39,7 +36,6 @@ class TestAddCommitterFactory(TestCase):
         mock_print.assert_called_once_with('Too many arguments.')
 
     def test_execute_prints_the_error_message_and_help_message_when_there_are_not_enough_args(self, mock_print,
-                                                                                              mock_add_commiter,
                                                                                               mock_context):
         command = AddCommitterFactory().build(['guet', 'initials', 'name'], Settings())
         command.execute()
@@ -51,20 +47,15 @@ class TestAddCommitterFactory(TestCase):
         ]
         mock_print.assert_has_calls(calls)
 
-    def test_get_short_help_message(self, mock_print, mock_add_commiter, mock_context):
+    def test_get_short_help_message(self, mock_print, mock_context):
         self.assertEqual('Add committer to the list of available committers',
                          AddCommitterFactory().short_help_message())
 
-    def test_execute_also_adds_committer_to_committers_file(self, mock_print, mock_add_commiter, mock_context):
-        command = AddCommitterFactory().build(['add', 'initials', 'name', 'email'], Settings())
-        command.execute()
 
-        mock_add_commiter.assert_called_with('initials', 'name', 'email')
-
-
+@patch('guet.commands.command_factory.Context')
 class TestBuildLocal(TestCase):
 
-    def test_uses_add_local_strategy_when_given_local_flag(self):
+    def test_uses_add_local_strategy_when_given_local_flag(self, mock_context):
         initials = 'initials'
         name = 'name'
         email = 'email'

--- a/test/commands/addcommitter/test_factory.py
+++ b/test/commands/addcommitter/test_factory.py
@@ -60,5 +60,4 @@ class TestBuildLocal(TestCase):
         name = 'name'
         email = 'email'
         command = AddCommitterFactory().build(['add', '--local', initials, name, email], Settings())
-        command.execute()
         self.assertIsInstance(command.strategy, AddCommitterLocallyStrategy)

--- a/test/committers/test_global_committer.py
+++ b/test/committers/test_global_committer.py
@@ -1,0 +1,12 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+from guet.committers.global_committer import GlobalCommitter
+
+
+@patch('guet.committers.global_committer.add_committer')
+class TestGlobalCommitterSave(TestCase):
+    def test_adds_committer_on_save(self, mock_add_committer):
+        committer = GlobalCommitter(name='name', email='email', initials='initials')
+        committer.save()
+        mock_add_committer.assert_called_with('initials', 'name', 'email')

--- a/test/committers/test_local_committer.py
+++ b/test/committers/test_local_committer.py
@@ -1,0 +1,15 @@
+from os.path import join
+from unittest import TestCase
+from unittest.mock import patch
+
+from guet import constants
+from guet.committers.local_committer import LocalCommitter
+
+
+@patch('guet.committers.local_committer.add_committer')
+class TestLocalCommitterSave(TestCase):
+    def test_adds_committer_to_project_root(self, mock_add_committer):
+        committer = LocalCommitter('name', 'email', 'initials', '/path/to/root')
+        committer.save()
+        file_path = join('/path/to/root', '.guet', constants.COMMITTERS)
+        mock_add_committer.assert_called_with('initials', 'name', 'email', file_path=file_path)

--- a/test/config/test_add_committer.py
+++ b/test/config/test_add_committer.py
@@ -17,7 +17,7 @@ class AddCommitterTest(unittest.TestCase):
         ]
         add_committer('initials3', 'name3', 'email3')
         mock_open.assert_any_call(join(app_config_directory_path, constants.COMMITTERS), 'r')
-        mock_open.assert_any_call(join(app_config_directory_path, constants.COMMITTERS), 'w')
+        mock_open.assert_any_call(join(app_config_directory_path, constants.COMMITTERS), 'w+')
         mock_open.return_value.writelines.assert_called_with([
             'initials1,name1,email1\n',
             'initials2,name2,email2\n',

--- a/test/config/test_add_committer.py
+++ b/test/config/test_add_committer.py
@@ -17,7 +17,7 @@ class AddCommitterTest(unittest.TestCase):
         ]
         add_committer('initials3', 'name3', 'email3')
         mock_open.assert_any_call(join(app_config_directory_path, constants.COMMITTERS), 'r')
-        mock_open.assert_any_call(join(app_config_directory_path, constants.COMMITTERS), 'w+')
+        mock_open.assert_any_call(join(app_config_directory_path, constants.COMMITTERS), 'w')
         mock_open.return_value.writelines.assert_called_with([
             'initials1,name1,email1\n',
             'initials2,name2,email2\n',
@@ -38,3 +38,25 @@ class AddCommitterTest(unittest.TestCase):
             'initials3,name3,email3\n'
         ])
 
+    @patch('builtins.open', new_callable=unittest.mock.mock_open())
+    def test_providing_a_file_path_uses_that_file_path_instead(self, mock_open):
+        mock_open.return_value.readlines.side_effect = FileNotFoundError()
+        add_committer('initials3', 'name3', 'email3')
+        mock_open.return_value.writelines.assert_called_with([
+            'initials3,name3,email3\n',
+        ])
+
+    @patch('builtins.open', new_callable=unittest.mock.mock_open())
+    def test_read_returns_empty_list_when_file_doesnt_exist(self, mock_open):
+        mock_open.return_value.readlines.return_value = [
+            'initials1,name1,email1\n',
+            'initials2,name2,email2\n'
+        ]
+        add_committer('initials3', 'name3', 'email3')
+        mock_open.assert_any_call(join(app_config_directory_path, constants.COMMITTERS), 'r')
+        mock_open.assert_any_call(join(app_config_directory_path, constants.COMMITTERS), 'w')
+        mock_open.return_value.writelines.assert_called_with([
+            'initials1,name1,email1\n',
+            'initials2,name2,email2\n',
+            'initials3,name3,email3\n',
+        ])

--- a/test/config/test_committers.py
+++ b/test/config/test_committers.py
@@ -65,10 +65,7 @@ class TestCommitters(TestCase):
         committers.add(committer)
         committer.save.assert_not_called()
 
-    @patch('guet.config.committers.add_committer')
-    def test_add_saves_committer_in_list_of_all_committers(self,
-                                                           mock_add_committer,
-                                                           _1):
+    def test_add_saves_committer_in_list_of_all_committers(self, _1):
         committers = Committers()
         committer = Committer(name='name', email='email', initials='initials')
         committer.save = Mock()

--- a/test/config/test_committers.py
+++ b/test/config/test_committers.py
@@ -1,6 +1,6 @@
 from os.path import join
 from unittest import TestCase
-from unittest.mock import patch, call
+from unittest.mock import patch, call, Mock
 
 from guet import constants
 from guet.config import CONFIGURATION_DIRECTORY
@@ -47,26 +47,23 @@ class TestCommitters(TestCase):
         actual = committers.all()
         self.assertListEqual(expected_committers, actual)
 
-    @patch('guet.config.committers.add_committer')
-    def test_add_writes_committer_to_file(self,
-                                          mock_add_committer,
-                                          _1):
+    def test_add_writes_committer_to_file(self, _1):
         committers = Committers()
         committer = Committer(name='name', email='email', initials='initials')
+        committer.save = Mock()
         committers.add(committer)
-        mock_add_committer.assert_called_with('initials', 'name', 'email')
+        committer.save.assert_called()
 
-    @patch('guet.config.committers.add_committer')
     def test_add_doesnt_write_committer_to_file_if_committer_already_present(self,
-                                                                             mock_add_committer,
                                                                              mock_read_lines):
         mock_read_lines.side_effect = [[
             'initials,name,email\n',
         ], FileNotFoundError()]
         committers = Committers()
         committer = Committer(name='name', email='email', initials='initials')
+        committer.save = Mock()
         committers.add(committer)
-        mock_add_committer.assert_not_called()
+        committer.save.assert_not_called()
 
     @patch('guet.config.committers.add_committer')
     def test_add_saves_committer_in_list_of_all_committers(self,
@@ -74,6 +71,7 @@ class TestCommitters(TestCase):
                                                            _1):
         committers = Committers()
         committer = Committer(name='name', email='email', initials='initials')
+        committer.save = Mock()
         committers.add(committer)
         self.assertIn(committer, committers.all())
 

--- a/test/config/test_committers.py
+++ b/test/config/test_committers.py
@@ -1,6 +1,6 @@
 from os.path import join
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import patch, call
 
 from guet import constants
 from guet.config import CONFIGURATION_DIRECTORY
@@ -8,13 +8,13 @@ from guet.config.committer import Committer
 from guet.config.committers import Committers
 from guet.config.errors import InvalidInitialsError
 
-default_mock_read_lines_return_value = [
+default_read_lines_side_effects = [[
     'initials1,name1,email1\n',
     'initials2,name2,email2\n'
-]
+], FileNotFoundError()]
 
 
-@patch('guet.config.committers.read_lines', return_value=default_mock_read_lines_return_value)
+@patch('guet.config.committers.read_lines', side_effect=default_read_lines_side_effects)
 class TestCommitters(TestCase):
     @patch('guet.config.committers.set_committer_as_author')
     @patch('guet.config.committers.set_current_committers')
@@ -60,9 +60,9 @@ class TestCommitters(TestCase):
     def test_add_doesnt_write_committer_to_file_if_committer_already_present(self,
                                                                              mock_add_committer,
                                                                              mock_read_lines):
-        mock_read_lines.return_value = [
+        mock_read_lines.side_effect = [[
             'initials,name,email\n',
-        ]
+        ], FileNotFoundError()]
         committers = Committers()
         committer = Committer(name='name', email='email', initials='initials')
         committers.add(committer)
@@ -79,9 +79,9 @@ class TestCommitters(TestCase):
 
     @patch('guet.config.committers.write_lines')
     def test_remove_removes_committer_from_list_committers(self, mock_write_lines, mock_read_lines):
-        mock_read_lines.return_value = [
+        mock_read_lines.side_effect = [[
             'initials,name,email\n'
-        ]
+        ], FileNotFoundError()]
         committers = Committers()
         committer = Committer(name='name', email='email', initials='initials')
         committers.remove(committer)
@@ -108,3 +108,29 @@ class TestCommitters(TestCase):
             self.fail('Should raise exceotion')
         except InvalidInitialsError:
             pass
+
+
+something = [[
+    'initials1,name1,email1\n',
+    'initials2,name2,email2\n'
+], [
+    'initials1,othername1,otheremail1\n'
+]]
+
+
+@patch('guet.config.committers.read_lines', side_effect=something)
+class TestCommittersWithLocal(TestCase):
+    path_to_project_root = '/path/to/project/root'
+
+    def test_loads_committers_from_global_file_and_local_file(self, mock_read_lines):
+        Committers(path_to_project_root=self.path_to_project_root)
+        mock_read_lines.assert_has_calls([
+            call(join(CONFIGURATION_DIRECTORY, constants.COMMITTERS)),
+            call(join(self.path_to_project_root, '.guet', constants.COMMITTERS))
+        ])
+
+    def test_local_committers_overwrite_global_committers_with_matching_initials(self, mock_read_lines):
+        committers = Committers(path_to_project_root=self.path_to_project_root)
+        local_committer1 = Committer(initials='initials1', name='othername1', email='otheremail1')
+        global_commtter2 = Committer(initials='initials2', name='name2', email='email2')
+        self.assertListEqual([local_committer1, global_commtter2], committers.all())

--- a/test/context/test_context.py
+++ b/test/context/test_context.py
@@ -60,3 +60,8 @@ class TestContext(TestCase):
         mock_git.side_effect = NoGitPresentError()
         context = Context('path/to/project/root/')
         self.assertNotIn(mock_git.return_value, context.current_committers_observer)
+
+    def test_committers_loaded_with_project_root(self, _1, mock_committers):
+        context = Context('path/to/project/root/')
+        context.__getattribute__('committers')
+        mock_committers.assert_called_with(path_to_project_root='path/to/project/root/')


### PR DESCRIPTION
## Overview
Adds the ability to save committers locally to a repository.

Connects #67 

### Demo
```
$ guet add n1 name1 name1@test.com
$ guet add --local n1 other1 other1@test.com
Adding committer with initials "n1" shadows the global committer "n1" - "name1" <name1@test.com>
$ guet get committers
All committers
n1 - other1 <other1@test.com>
```