### PR TITLE
Print error message when running guet set from folder without git

### DIFF
--- a/e2e/test_setcommitter.py
+++ b/e2e/test_setcommitter.py
@@ -2,7 +2,7 @@ import time
 
 from e2e import DockerTest
 from guet.commands.init_required_decorator import INIT_REQUIRED_ERROR_MESSAGE
-from guet.commands.start_required_decorator import GUET_NOT_STARTED_ERROR
+from guet.commands.start_required_decorator import GUET_NOT_STARTED_ERROR, NOT_RAN_IN_ROOT_DIRECTORY_ERROR
 
 
 class TestGuetSet(DockerTest):
@@ -60,3 +60,17 @@ class TestGuetSet(DockerTest):
         self.execute()
 
         self.assert_text_in_logs(1, GUET_NOT_STARTED_ERROR)
+
+    def test_errors_if_ran_in_folder_with_no_git(self):
+        self.guet_init()
+        self.git_init()
+        self.guet_add('initials1', 'name1', 'email1')
+        self.guet_add('initials2', 'name2', 'email2')
+        self.guet_start()
+        self.add_command('mkdir api')
+        self.change_directory('api')
+        self.guet_set(['initials1', 'initials2'])
+
+        self.execute()
+
+        self.assert_text_in_logs(1, NOT_RAN_IN_ROOT_DIRECTORY_ERROR)

--- a/guet/commands/start_required_decorator.py
+++ b/guet/commands/start_required_decorator.py
@@ -4,6 +4,7 @@ from guet.commands.command import Command
 from guet.commands.command_factory_decorator import CommandFactoryDecorator
 from guet.commands.print_strategy import PrintCommandStrategy
 from guet.commands.strategy_command import StrategyCommand
+from guet.git.errors import NoGitPresentError
 from guet.git.git import Git
 from guet.git.git_path_from_cwd import git_path_from_cwd
 from guet.settings.settings import Settings
@@ -14,11 +15,19 @@ GUET_NOT_STARTED_ERROR = (
     'for use with guet.'
 )
 
+NOT_RAN_IN_ROOT_DIRECTORY_ERROR = (
+    'You are not in a directory with a git folder. Change back'
+    'to your project\'s root directory.'
+)
+
 
 class StartRequiredDecorator(CommandFactoryDecorator):
     def build(self, args: List[str], settings: Settings) -> Command:
-        git = Git(git_path_from_cwd())
-        if git.hooks_present():
-            return self.decorated.build(args, settings)
-        else:
-            return StrategyCommand(PrintCommandStrategy(GUET_NOT_STARTED_ERROR))
+        try:
+            git = Git(git_path_from_cwd())
+            if git.hooks_present():
+                return self.decorated.build(args, settings)
+            else:
+                return StrategyCommand(PrintCommandStrategy(GUET_NOT_STARTED_ERROR))
+        except NoGitPresentError:
+            return StrategyCommand(PrintCommandStrategy(NOT_RAN_IN_ROOT_DIRECTORY_ERROR))

--- a/test/commands/test_start_required_decorator.py
+++ b/test/commands/test_start_required_decorator.py
@@ -2,7 +2,8 @@ from unittest import TestCase
 from unittest.mock import Mock, patch
 
 from guet.commands.print_strategy import PrintCommandStrategy
-from guet.commands.start_required_decorator import StartRequiredDecorator
+from guet.commands.start_required_decorator import StartRequiredDecorator, NOT_RAN_IN_ROOT_DIRECTORY_ERROR
+from guet.git.errors import NoGitPresentError
 from guet.settings.settings import Settings
 
 
@@ -22,3 +23,11 @@ class TestStartRequiredDecorator(TestCase):
         command = decorator.build([], Settings())
 
         self.assertIsInstance(command.strategy, PrintCommandStrategy)
+
+    def test_returns_command_with_print_strategy_with_error_message(self, mock_git, mock_git_path_from_cwd):
+        mock_git.side_effect = NoGitPresentError()
+        decorator = StartRequiredDecorator(Mock())
+        command = decorator.build([], Settings())
+
+        self.assertIsInstance(command.strategy, PrintCommandStrategy)
+        self.assertEqual(NOT_RAN_IN_ROOT_DIRECTORY_ERROR, command.strategy._text)


### PR DESCRIPTION
## Overview
Displays a warning message when `guet set` is called from a folder without a `.git` folder.

Connects #69 

### Demo
Example of pull request in use in the following format:
```
$ guet add n1 name1 name1@example.com
$ guet add n2 name2 name2@example.com
$ mkdir api
$ cd api
$ guet set n1 n2
You are not in a directory with a git folder. Change back
to your project's root directory.
```