### PR TITLE
guet add --local correctly handles being in a subfolder

### DIFF
--- a/e2e/test_addcommitter.py
+++ b/e2e/test_addcommitter.py
@@ -48,6 +48,7 @@ class TestAddUser(DockerTest):
 
     def test_including_local_flag_adds_committer_to_the_repository(self):
         self.guet_init()
+        self.git_init()
         self.guet_add('initials', 'name1', 'email1', local=True)
         self.save_file_content('test-env/.guet/committers')
 
@@ -58,6 +59,7 @@ class TestAddUser(DockerTest):
 
     def test_adding_local_committers_only_saves_the_local_committers(self):
         self.guet_init()
+        self.git_init()
         self.guet_add('initials1', 'name1', 'email1')
         self.guet_add('initials2', 'name2', 'email2', local=True)
         self.save_file_content('test-env/.guet/committers')
@@ -76,3 +78,16 @@ class TestAddUser(DockerTest):
 
         self.assert_text_in_logs(0, ('Adding committer with initials "initials" shadows the '
                                      'global committer "initials" - "name1" <email1>'))
+
+    def test_adding_local_committer_in_subfolder_adds_committer_to_root_directory(self):
+        self.guet_init()
+        self.git_init()
+        self.add_command('mkdir ui')
+        self.change_directory('ui')
+        self.guet_add('initials1', 'name1', 'email1', local=True)
+        self.save_file_content('test-env/.guet/committers')
+
+        self.execute()
+
+        text = self.get_file_text('test-env/.guet/committers')
+        self.assertListEqual(['initials1,name1,email1'], text)

--- a/e2e/test_addcommitter.py
+++ b/e2e/test_addcommitter.py
@@ -91,3 +91,11 @@ class TestAddUser(DockerTest):
 
         text = self.get_file_text('test-env/.guet/committers')
         self.assertListEqual(['initials1,name1,email1'], text)
+
+    def test_adding_local_committers_with_no_git_prints_error_message(self):
+        self.guet_init()
+        self.guet_add('initials1', 'name1', 'email1', local=True)
+
+        self.execute()
+
+        self.assert_text_in_logs(0, 'No git folder, so project root cannot be determined.')

--- a/guet/commands/usercommands/addcommitter/factory.py
+++ b/guet/commands/usercommands/addcommitter/factory.py
@@ -66,7 +66,7 @@ class AddCommitterFactory(UserCommandFactory):
                 print((f'Adding committer with initials "{initials}" shadows the '
                        f'global committer "{found.initials}" - "{found.name}" <{found.email}>'))
             add_committers_strategy = AddCommitterLocallyStrategy(initials, name, email,
-                                                                  project_root=getcwd(),
+                                                                  project_root=self.context.project_root_directory,
                                                                   committers=self.context.committers)
         else:
             add_committers_strategy = AddCommitterGloballyStrategy(initials, name, email, self.context.committers)

--- a/guet/commands/usercommands/addcommitter/factory.py
+++ b/guet/commands/usercommands/addcommitter/factory.py
@@ -1,6 +1,6 @@
-from os import getcwd
 from typing import List
 
+from guet.commands.strategies.print_strategy import PrintCommandStrategy
 from guet.commands.usercommands.addcommitter.add_committer_locally_strategy import AddCommitterLocallyStrategy
 from guet.commands.usercommands.addcommitter.add_committer_strategy import AddCommitterGloballyStrategy
 from guet.commands.strategies.cancellable_strategy import CancelableCommandStrategy
@@ -56,7 +56,10 @@ class AddCommitterFactory(UserCommandFactory):
         elif len(_args_without_local_flag(args)) > 3:
             return TooManyArgsStrategy()
         else:
-            return self._choose_creation_strategy(args)
+            try:
+                return self._choose_creation_strategy(args)
+            except FileNotFoundError:
+                return PrintCommandStrategy('No git folder, so project root cannot be determined.')
 
     def _choose_creation_strategy(self, args):
         initials, name, email = _args_without_local_flag(args)

--- a/test/commands/usercommands/addcommitter/test_factory.py
+++ b/test/commands/usercommands/addcommitter/test_factory.py
@@ -52,12 +52,16 @@ class TestAddCommitterFactory(TestCase):
                          AddCommitterFactory().short_help_message())
 
 
+@patch('guet.commands.usercommands.addcommitter.factory.AddCommitterLocallyStrategy')
 @patch('guet.commands.command_factory.Context')
 class TestBuildLocal(TestCase):
 
-    def test_uses_add_local_strategy_when_given_local_flag(self, mock_context):
+    def test_uses_add_local_strategy_when_given_local_flag(self, mock_context, mock_strategy):
+        instance: Context = mock_context.instance.return_value
         initials = 'initials'
         name = 'name'
         email = 'email'
         command = AddCommitterFactory().build(['add', '--local', initials, name, email], Settings())
-        self.assertIsInstance(command.strategy, AddCommitterLocallyStrategy)
+        self.assertEqual(command.strategy, mock_strategy.return_value)
+        mock_strategy.assert_called_with(initials, name, email, project_root=instance.project_root_directory,
+                                         committers=instance.committers)

--- a/test/commands/usercommands/addcommitter/test_factory.py
+++ b/test/commands/usercommands/addcommitter/test_factory.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from unittest.mock import patch, call, Mock
+from unittest.mock import patch, call, Mock, PropertyMock
 
 from guet.commands.usercommands.addcommitter.add_committer_locally_strategy import AddCommitterLocallyStrategy
 from guet.commands.usercommands.addcommitter.factory import AddCommitterFactory, ADD_COMMITTER_HELP_MESSAGE
@@ -52,11 +52,11 @@ class TestAddCommitterFactory(TestCase):
                          AddCommitterFactory().short_help_message())
 
 
-@patch('guet.commands.usercommands.addcommitter.factory.AddCommitterLocallyStrategy')
 @patch('guet.commands.command_factory.Context')
 class TestBuildLocal(TestCase):
 
-    def test_uses_add_local_strategy_when_given_local_flag(self, mock_context, mock_strategy):
+    @patch('guet.commands.usercommands.addcommitter.factory.AddCommitterLocallyStrategy')
+    def test_uses_add_local_strategy_when_given_local_flag(self, mock_strategy, mock_context):
         instance: Context = mock_context.instance.return_value
         initials = 'initials'
         name = 'name'


### PR DESCRIPTION
## Overview
When adding a local committer from a subfolder, configurations is added to the root directory of the project.

### Demo
```
$ cd api/
$ guet add --local n1 name1 name1@example.com
```
A `.guet` directory with `name1`'s information will exist in the root directory of the project.