### PR TITLE
Ignore case of initials when adding, setting, or removing committers

### DIFF
--- a/e2e/test_addcommitter.py
+++ b/e2e/test_addcommitter.py
@@ -46,6 +46,13 @@ class TestAddUser(DockerTest):
         self.assert_text_in_logs(2, 'initials - name2 <email2>')
         self.assert_text_in_logs(5, 'initials - name2 <email2>')
 
+    def test_initials_are_lower_case_when_saved(self):
+        self.guet_init()
+        self.guet_add('INITIALS', 'name1', 'email1')
+        self.guet_get_committers()
+        self.execute()
+        self.assert_text_in_logs(1, 'initials - name1 <email1>')
+
     def test_including_local_flag_adds_committer_to_the_repository(self):
         self.guet_init()
         self.git_init()

--- a/e2e/test_removecommitter.py
+++ b/e2e/test_removecommitter.py
@@ -14,6 +14,17 @@ class TestRemoveCommitter(DockerTest):
         self.assert_text_in_logs(0, 'All committers')
         self.assert_text_in_logs(1, '')
 
+    def test_remove_ignores_case_of_initials(self):
+        self.guet_init()
+        self.guet_add('initials', 'name', 'email')
+        self.guet_remove('INITIALS')
+        self.guet_get_committers()
+
+        self.execute()
+
+        self.assert_text_in_logs(0, 'All committers')
+        self.assert_text_in_logs(1, '')
+
     def test_removing_initials_not_in_system_prints_error_message(self):
         self.guet_init()
         self.guet_remove('initials')

--- a/e2e/test_setcommitter.py
+++ b/e2e/test_setcommitter.py
@@ -37,6 +37,22 @@ class TestGuetSet(DockerTest):
         self.assertEqual('initials2', set_text_split[1])
         self.assertTrue(start_time + 10000 > int(set_text_split[2]) > start_time)
 
+    def test_set_committers_ignores_case_of_initials(self):
+        self.guet_init()
+        self.git_init()
+        self.guet_add('initials1', 'name1', 'email1')
+        self.guet_add('initials2', 'name2', 'email2')
+        self.guet_start()
+        self.guet_set(['INITIALS1', 'initials2'])
+        self.guet_get_current()
+
+        self.execute()
+
+        self.assert_text_in_logs(1, 'Currently set committers')
+        self.assert_text_in_logs(2, 'initials1 - name1 <email1>')
+        self.assert_text_in_logs(3, 'initials2 - name2 <email2>')
+
+
     def test_set_committer_required_init_to_have_ran_before_usage(self):
         self.guet_set(['initials1'])
         self.execute()

--- a/guet/commands/usercommands/addcommitter/factory.py
+++ b/guet/commands/usercommands/addcommitter/factory.py
@@ -63,6 +63,7 @@ class AddCommitterFactory(UserCommandFactory):
 
     def _choose_creation_strategy(self, args):
         initials, name, email = _args_without_local_flag(args)
+        initials = str.lower(initials)
         found = self._commiter_with_matching_initials(initials)
         if _should_add_local(args):
             if found:

--- a/guet/commands/usercommands/remove/remove_strategy.py
+++ b/guet/commands/usercommands/remove/remove_strategy.py
@@ -9,7 +9,7 @@ def _without_committer_with_initials(initials, all_committers):
 
 class RemoveCommitterStrategy(CommandStrategy):
     def __init__(self, initials: str, context: Context):
-        self._initials = initials
+        self._initials = str.lower(initials)
         self.context = context
 
     def apply(self):

--- a/guet/commands/usercommands/setcommitters/set_committers_strategy.py
+++ b/guet/commands/usercommands/setcommitters/set_committers_strategy.py
@@ -13,7 +13,7 @@ class SetCommittersStrategy(CommandStrategy):
 
     def apply(self):
         committers = self.context.committers.all()
-        committer_initials = self.args
+        committer_initials = [str.lower(initials) for initials in self.args]
         committers_to_set = filter_committers_with_initials(committers, committer_initials)
 
         correct_number_of_committers_present = len(committers_to_set) is len(committer_initials)


### PR DESCRIPTION
## Overview
Ignore case of initials when adding, setting, or removing committers

Connects #60 

### Demo
Example of pull request in use in the following format:
```
$ guet add INITIALS name email
$ guet set initials
$ guet remove INITIALS
```
All commands are processed as though "initials" was used.