### PR TITLE
Local shadow add

### DIFF
--- a/e2e/test_addcommitter.py
+++ b/e2e/test_addcommitter.py
@@ -80,13 +80,18 @@ class TestAddUser(DockerTest):
 
     def test_prints_warning_message_when_adding_local_committer_that_has_same_initials_as_global_committer(self):
         self.guet_init()
+        self.git_init()
+        self.guet_start()
         self.guet_add('initials', 'name1', 'email1')
-        self.guet_add('initials', 'name2', 'emial2', local=True)
+        self.guet_add('initials', 'name2', 'email2', local=True)
+        self.save_file_content('test-env/.guet/committers')
 
         self.execute()
 
-        self.assert_text_in_logs(0, ('Adding committer with initials "initials" shadows the '
+        self.assert_text_in_logs(1, ('Adding committer with initials "initials" shadows the '
                                      'global committer "initials" - "name1" <email1>'))
+        text = self.get_file_text('test-env/.guet/committers')
+        self.assertListEqual(['initials,name2,email2'], text)
 
     def test_adding_local_committer_in_subfolder_adds_committer_to_root_directory(self):
         self.guet_init()

--- a/e2e/test_addcommitter.py
+++ b/e2e/test_addcommitter.py
@@ -56,6 +56,7 @@ class TestAddUser(DockerTest):
     def test_including_local_flag_adds_committer_to_the_repository(self):
         self.guet_init()
         self.git_init()
+        self.guet_start()
         self.guet_add('initials', 'name1', 'email1', local=True)
         self.save_file_content('test-env/.guet/committers')
 
@@ -67,6 +68,7 @@ class TestAddUser(DockerTest):
     def test_adding_local_committers_only_saves_the_local_committers(self):
         self.guet_init()
         self.git_init()
+        self.guet_start()
         self.guet_add('initials1', 'name1', 'email1')
         self.guet_add('initials2', 'name2', 'email2', local=True)
         self.save_file_content('test-env/.guet/committers')
@@ -76,7 +78,7 @@ class TestAddUser(DockerTest):
         text = self.get_file_text('test-env/.guet/committers')
         self.assertListEqual(['initials2,name2,email2'], text)
 
-    def test_prints_error_message_when_adding_local_committer_that_has_same_initials_as_global_committer(self):
+    def test_prints_warning_message_when_adding_local_committer_that_has_same_initials_as_global_committer(self):
         self.guet_init()
         self.guet_add('initials', 'name1', 'email1')
         self.guet_add('initials', 'name2', 'emial2', local=True)
@@ -89,6 +91,7 @@ class TestAddUser(DockerTest):
     def test_adding_local_committer_in_subfolder_adds_committer_to_root_directory(self):
         self.guet_init()
         self.git_init()
+        self.guet_start()
         self.add_command('mkdir ui')
         self.change_directory('ui')
         self.guet_add('initials1', 'name1', 'email1', local=True)
@@ -99,10 +102,12 @@ class TestAddUser(DockerTest):
         text = self.get_file_text('test-env/.guet/committers')
         self.assertListEqual(['initials1,name1,email1'], text)
 
-    def test_adding_local_committers_with_no_git_prints_error_message(self):
+    def test_adding_local_committers_when_not_started_error_message(self):
         self.guet_init()
+        self.git_init()
         self.guet_add('initials1', 'name1', 'email1', local=True)
 
         self.execute()
 
-        self.assert_text_in_logs(0, 'No git folder, so project root cannot be determined.')
+        self.assert_text_in_logs(1,
+                                 'guet not initialized in this repository. Please use guet start to initialize repository for use with guet.')

--- a/e2e/test_setcommitter.py
+++ b/e2e/test_setcommitter.py
@@ -101,6 +101,7 @@ class TestGuetSet(DockerTest):
     def test_setting_committers_includes_local_committers(self):
         self.guet_init()
         self.git_init()
+        self.guet_start()
         self.guet_add('initials1', 'name1', 'email1', local=True)
         self.guet_add('initials2', 'name2', 'email2')
         self.guet_start()

--- a/guet/commands/decorators/local_decorator.py
+++ b/guet/commands/decorators/local_decorator.py
@@ -1,0 +1,15 @@
+from typing import List
+
+from guet.commands.command import Command
+from guet.commands.decorators.command_factory_decorator import CommandFactoryDecorator
+from guet.commands.decorators.start_required_decorator import StartRequiredDecorator
+from guet.settings.settings import Settings
+
+
+class LocalDecorator(CommandFactoryDecorator):
+
+    def build(self, args: List[str], settings: Settings) -> Command:
+        if '--local' in args:
+            return StartRequiredDecorator(self.decorated).build(args, settings)
+        else:
+            return self.decorated.build(args, settings)

--- a/guet/commands/decorators/start_required_decorator.py
+++ b/guet/commands/decorators/start_required_decorator.py
@@ -16,8 +16,7 @@ GUET_NOT_STARTED_ERROR = (
 )
 
 NOT_RAN_IN_ROOT_DIRECTORY_ERROR = (
-    'You are not in a directory with a git folder. Change back'
-    'to your project\'s root directory.'
+    'No git folder, so project root cannot be determined.'
 )
 
 

--- a/guet/commands/usercommands/addcommitter/add_committer_locally_strategy.py
+++ b/guet/commands/usercommands/addcommitter/add_committer_locally_strategy.py
@@ -18,7 +18,7 @@ class AddCommitterLocallyStrategy(CommandStrategy):
         self._create_local_guet_folder_if_not_exists()
         committer = LocalCommitter(name=self._name, email=self._email, initials=self._initials,
                                    project_root=self._project_root)
-        self._committers.add(committer)
+        self._committers.add(committer, replace=True)
 
     def _create_local_guet_folder_if_not_exists(self) -> None:
         folder_path = join(self._project_root, '.guet')

--- a/guet/committers/committers.py
+++ b/guet/committers/committers.py
@@ -93,8 +93,8 @@ class Committers(SetCommitterObserver):
                 pass
         return final
 
-    def add(self, committer: Committer):
-        if committer not in self.all():
+    def add(self, committer: Committer, *, replace: bool = False):
+        if committer not in self.all() or replace:
             self._committers.append(committer)
             committer.save()
 

--- a/guet/main.py
+++ b/guet/main.py
@@ -1,5 +1,6 @@
 import sys
 
+from guet.commands.decorators.local_decorator import LocalDecorator
 from guet.commands.usercommands.get.get_factory import GetCommandFactory, GET_HELP_MESSAGE
 from guet.commands.decorators.git_required_decorator import GitRequiredDecorator
 from guet.commands.decorators.help_decorator import HelpDecorator
@@ -19,7 +20,12 @@ from guet.commands.usercommands.config.factory import ConfigCommandFactory, CONF
 def _command_builder_map():
     command_builder_map = dict()
     command_builder_map['add'] = VersionDecorator(
-        InitRequiredDecorator(HelpDecorator(AddCommitterFactory(), ADD_COMMITTER_HELP_MESSAGE)))
+        InitRequiredDecorator(
+            LocalDecorator(
+                HelpDecorator(AddCommitterFactory(), ADD_COMMITTER_HELP_MESSAGE)
+            )
+        )
+    )
 
     command_builder_map['init'] = VersionDecorator(
         HelpDecorator(InitCommandFactory(), INIT_HELP_MESSAGE, no_args_valid=True))

--- a/test/commands/decorators/test_local_decorator.py
+++ b/test/commands/decorators/test_local_decorator.py
@@ -1,0 +1,27 @@
+from unittest import TestCase
+from unittest.mock import Mock, patch
+
+from guet.settings.settings import Settings
+
+from guet.commands.decorators.local_decorator import LocalDecorator
+
+
+class LocalDecoratorTest(TestCase):
+
+    def test_calls_build_on_decorated_when_local_flag_not_in_args(self):
+        mock_factory = Mock()
+        mock_command = Mock()
+        mock_factory.build.return_value = mock_command
+        decorator = LocalDecorator(mock_factory)
+        self.assertEqual(mock_command, decorator.build(['args', 'without', 'flag'], Settings()))
+
+    @patch('guet.commands.decorators.local_decorator.StartRequiredDecorator')
+    def test_wraps_decorated_in_start_required_decorator_and_calls_build_when_local_flag_present(self,
+                                                                                                 mock_start_required_decorator):
+        mock_factory = Mock()
+        mock_command = Mock()
+        mock_factory.build.return_value = mock_command
+        decorator = LocalDecorator(mock_factory)
+        mock_start_decorator_instance = mock_start_required_decorator.return_value
+        self.assertEqual(mock_start_decorator_instance.build.return_value,
+                         decorator.build(['args', 'with', '--local', 'flag'], Settings()))

--- a/test/commands/usercommands/addcommitter/test_add_committer_local_strategy.py
+++ b/test/commands/usercommands/addcommitter/test_add_committer_local_strategy.py
@@ -16,7 +16,7 @@ class TestAddLocalCommitterStrategy(TestCase):
         strategy.apply()
 
         expected = LocalCommitter(name='name', email='email', initials='initials', project_root='/path/to/root')
-        committers.add.assert_called_with(expected)
+        committers.add.assert_called_with(expected, replace=True)
 
     def test_apply_creates_a_guet_directory_at_project_root_if_one_does_not_exist_already(self, mock_isdir, mock_mkdir):
         mock_isdir.return_value = False

--- a/test/committers/test_committers.py
+++ b/test/committers/test_committers.py
@@ -2,6 +2,8 @@ from os.path import join
 from unittest import TestCase
 from unittest.mock import patch, call, Mock
 
+from guet.committers.local_committer import LocalCommitter
+
 from guet import constants
 from guet.config import CONFIGURATION_DIRECTORY
 from guet.committers.committer import Committer
@@ -213,3 +215,16 @@ class TestCommittersWithLocal(TestCase):
         local_committer1 = Committer(initials='initials1', name='othername1', email='otheremail1')
         global_commtter2 = Committer(initials='initials2', name='name2', email='email2')
         self.assertListEqual([local_committer1, global_commtter2], committers.all())
+
+    def test_add_with_replace_flag_removes_committer_with_matching_initials(self, mock_read_lines):
+        default_read_lines_side_effects = [[
+            'initials1,name1,email1\n',
+            'initials2,name2,email2\n'
+        ], FileNotFoundError()]
+        mock_read_lines.side_effect = default_read_lines_side_effects
+        committers = Committers(path_to_project_root=self.path_to_project_root)
+        committer_with_matching_initials = LocalCommitter(name='name1', email='email1', initials='initials1',
+                                                          project_root='path')
+        committer_with_matching_initials.save = Mock()
+        committers.add(committer_with_matching_initials, replace=True)
+        committer_with_matching_initials.save.assert_called()

--- a/test/committers/test_local_committer.py
+++ b/test/committers/test_local_committer.py
@@ -8,6 +8,7 @@ from guet.committers.local_committer import LocalCommitter
 
 @patch('guet.committers.local_committer.add_committer')
 class TestLocalCommitterSave(TestCase):
+
     def test_adds_committer_to_project_root(self, mock_add_committer):
         committer = LocalCommitter('name', 'email', 'initials', '/path/to/root')
         committer.save()


### PR DESCRIPTION
## Overview

Fixes bug where adding a committer locally that exactly matches a global committer won't create them locally.

### Demo
```
$ guet add n "Name" name@example.com
$ guet add n "Name" name@example.com --local
$ cat .guet/committers
n,Name,name@example.com
```