### PR TITLE
Change python shebang if python3 is not available

### DIFF
--- a/guet/git/hook.py
+++ b/guet/git/hook.py
@@ -1,14 +1,26 @@
 from os import chmod, stat
+from shutil import which
+from typing import List
 
 from guet.files.read_lines import read_lines
 from guet.files.write_lines import write_lines
 
-GUET_HOOK_FILE = [
-    '#! /usr/bin/env python3',
-    'from guet.hooks import manage',
-    'import sys',
-    'manage(sys.argv[0])',
-]
+
+def _shared_hook_lines() -> List[str]:
+    return [
+        'from guet.hooks import manage',
+        'import sys',
+        'manage(sys.argv[0])',
+    ]
+
+
+PYTHON_GUET_HOOK = [
+                       '#! /usr/bin/env python',
+                   ] + _shared_hook_lines()
+
+PYTHON3_GUET_HOOK = [
+                        '#! /usr/bin/env python3',
+                    ] + _shared_hook_lines()
 
 
 class Hook:
@@ -20,28 +32,31 @@ class Hook:
         return f'Hook: path: {self.path}, content: {self.content}'
 
     def is_guet_hook(self):
-        return self.content == GUET_HOOK_FILE
+        return self.content == PYTHON3_GUET_HOOK or self.content == PYTHON_GUET_HOOK
 
     @staticmethod
     def _parse_file_content(create, path_to_hook):
         _content = Hook._get_file_content(path_to_hook, create)
-        if _content != GUET_HOOK_FILE:
+        if _content != PYTHON3_GUET_HOOK and _content != PYTHON_GUET_HOOK:
             _content = Hook._handle_mismatched_content(_content, create)
         return _content
 
     @staticmethod
     def _handle_mismatched_content(_content, create):
         if create:
-            _content = GUET_HOOK_FILE
+            _content = PYTHON3_GUET_HOOK
         return _content
 
     @staticmethod
-    def _get_file_content(path_to_hook, create):
+    def _get_file_content(path_to_hook, create: bool):
         try:
             _content = read_lines(path_to_hook)
         except FileNotFoundError:
             if create:
-                _content = GUET_HOOK_FILE
+                if not which('python3'):
+                    _content = PYTHON_GUET_HOOK
+                else:
+                    _content = PYTHON3_GUET_HOOK
             else:
                 raise
         return _content

--- a/guet/git/hook.py
+++ b/guet/git/hook.py
@@ -14,13 +14,9 @@ def _shared_hook_lines() -> List[str]:
     ]
 
 
-PYTHON_GUET_HOOK = [
-                       '#! /usr/bin/env python',
-                   ] + _shared_hook_lines()
+PYTHON_GUET_HOOK = ['#! /usr/bin/env python'] + _shared_hook_lines()
 
-PYTHON3_GUET_HOOK = [
-                        '#! /usr/bin/env python3',
-                    ] + _shared_hook_lines()
+PYTHON3_GUET_HOOK = ['#! /usr/bin/env python3'] + _shared_hook_lines()
 
 
 class Hook:
@@ -37,7 +33,7 @@ class Hook:
     @staticmethod
     def _parse_file_content(create, path_to_hook):
         _content = Hook._get_file_content(path_to_hook, create)
-        if _content != PYTHON3_GUET_HOOK and _content != PYTHON_GUET_HOOK:
+        if _content not in (PYTHON3_GUET_HOOK, PYTHON_GUET_HOOK):
             _content = Hook._handle_mismatched_content(_content, create)
         return _content
 

--- a/test/git/test_hook.py
+++ b/test/git/test_hook.py
@@ -2,23 +2,24 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from guet.git.errors import NotGuetHookError
-from guet.git.hook import Hook, GUET_HOOK_FILE
+from guet.git.hook import Hook, PYTHON3_GUET_HOOK, PYTHON_GUET_HOOK
 
 
-@patch('guet.git.hook.read_lines', return_value=GUET_HOOK_FILE)
+@patch('guet.git.hook.which', return_value='/path/to/python3')
+@patch('guet.git.hook.read_lines', return_value=PYTHON3_GUET_HOOK)
 class TestHook(TestCase):
 
-    def test_reads_content_to_hook(self, mock_read_lines):
+    def test_reads_content_to_hook(self, mock_read_lines, mock_which):
         hook = Hook('/path/to/.git/hooks/name')
         mock_read_lines.assert_called_with('/path/to/.git/hooks/name')
         self.assertEqual(mock_read_lines.return_value, hook.content)
 
-    def test_is_guet_hook_returns_whether_hook_matches_guet_content(self, mock_read_lines):
+    def test_is_guet_hook_returns_whether_hook_matches_guet_content(self, mock_read_lines, mock_which):
         mock_read_lines.return_value = ['Other', 'Content']
         hook = Hook('/path/to/.git/hooks/name')
         self.assertFalse(hook.is_guet_hook())
 
-    def test_works_with_specific_content(self, mock_read_lines):
+    def test_works_with_specific_content(self, mock_read_lines, mock_which):
         mock_read_lines.return_value = ['#! /usr/bin/env python3', 'from guet.hooks import manage', 'import sys',
                                         'manage(sys.argv[0])']
         try:
@@ -27,20 +28,21 @@ class TestHook(TestCase):
         except (NotGuetHookError, FileNotFoundError):
             self.fail('Should successfully create hook.')
 
-    def test_init_with_create_flag_catches_file_not_found_error_and_save_content_to_default(self, mock_read_lines):
+    def test_init_with_create_flag_catches_file_not_found_error_and_save_content_to_default(self, mock_read_lines,
+                                                                                            mock_which):
         mock_read_lines.side_effect = FileNotFoundError()
         hook = Hook('/path/to/.git/hooks/name', create=True)
-        self.assertEqual(GUET_HOOK_FILE, hook.content)
+        self.assertEqual(PYTHON3_GUET_HOOK, hook.content)
 
-    def test_init_with_create_flag_overwrites_already_present_content(self, mock_read_lines):
+    def test_init_with_create_flag_overwrites_already_present_content(self, mock_read_lines, mock_which):
         mock_read_lines.return_value = ['Other', 'Content']
         hook = Hook('/path/to/.git/hooks/name', create=True)
-        self.assertEqual(GUET_HOOK_FILE, hook.content)
+        self.assertEqual(PYTHON3_GUET_HOOK, hook.content)
 
     @patch('guet.git.hook.chmod')
     @patch('guet.git.hook.stat')
     @patch('guet.git.hook.write_lines')
-    def test_save_writes_lines_to_file(self, mock_write_lines, mock_stat, mock_chmod, mock_read_lines):
+    def test_save_writes_lines_to_file(self, mock_write_lines, mock_stat, mock_chmod, mock_read_lines, mock_which):
         mock_read_lines.side_effect = FileNotFoundError()
         path = '/path/to/.git/hooks/name'
         hook = Hook(path, create=True)
@@ -50,9 +52,27 @@ class TestHook(TestCase):
     @patch('guet.git.hook.chmod')
     @patch('guet.git.hook.stat')
     @patch('guet.git.hook.write_lines')
-    def test_save_chmods_file_to_executable(self, mock_write_lines, mock_stat, mock_chmod, mock_read_lines):
+    def test_save_chmods_file_to_executable(self, mock_write_lines, mock_stat, mock_chmod, mock_read_lines, mock_which):
         mock_read_lines.side_effect = FileNotFoundError()
         path = '/path/to/.git/hooks/name'
         hook = Hook(path, create=True)
         hook.save()
         mock_chmod.assert_called_with(path, mock_stat.return_value.st_mode | 0o111)
+
+    def test_is_get_hook_registers_python_shebang_without_the_3_as_guet_hook(self, mock_read_lines, mock_which):
+        mock_read_lines.return_value = PYTHON_GUET_HOOK
+        path = '/path/to/.git/hooks/name'
+        hook = Hook(path)
+        self.assertTrue(hook.is_guet_hook())
+
+    @patch('guet.git.hook.chmod')
+    @patch('guet.git.hook.stat')
+    @patch('guet.git.hook.write_lines')
+    def test_uses_python_if_python3_is_not_available(self, mock_write_lines, mock_stat, mock_chmod, mock_read_lines,
+                                                     mock_which):
+        mock_which.return_value = None
+        mock_read_lines.side_effect = FileNotFoundError()
+        path = '/path/to/.git/hooks/name'
+        hook = Hook(path, create=True)
+        hook.save()
+        mock_write_lines.assert_called_with(path, PYTHON_GUET_HOOK)


### PR DESCRIPTION
## Overview
Since the default shebag is `#! /usr/bin/env python3`, the hooks won't work if the system doesn't have `python3` (such as on Windows when installing python3 the command is `python`).

### Notes
Uses the `which()` utility in python to check if `python3` is available. If it's not, then it defaults to `python`. However, it won't check if `python` is installed.
