### PR TITLE
Better messages around commands

### DIFF
--- a/e2e/test_addcommitter.py
+++ b/e2e/test_addcommitter.py
@@ -88,7 +88,7 @@ class TestAddUser(DockerTest):
 
         self.execute()
 
-        self.assert_text_in_logs(1, ('Adding committer with initials "initials" shadows the '
+        self.assert_text_in_logs(2, ('Adding committer with initials "initials" shadows the '
                                      'global committer "initials" - "name1" <email1>'))
         text = self.get_file_text('test-env/.guet/committers')
         self.assertListEqual(['initials,name2,email2'], text)

--- a/e2e/test_commit.py
+++ b/e2e/test_commit.py
@@ -16,8 +16,8 @@ class TestCommit(DockerTest):
 
         self.execute()
 
-        self.assert_text_in_logs(11, '    Co-authored-by: name <email@localhost>')
-        self.assert_text_in_logs(12, '    Co-authored-by: name2 <email2@localhost>')
+        self.assert_text_in_logs(14, '    Co-authored-by: name <email@localhost>')
+        self.assert_text_in_logs(15, '    Co-authored-by: name2 <email2@localhost>')
 
     def test_if_only_one_committer_set_no_co_authored_by_lines_are_added(self):
         self.guet_init()
@@ -31,7 +31,7 @@ class TestCommit(DockerTest):
         self.show_git_log()
 
         self.execute()
-        self.assertEqual(11, len(self.logs))
+        self.assertEqual(13, len(self.logs))
 
     def test_replaces_co_authored_messages_when_editing_commit(self):
         self.guet_init()
@@ -52,8 +52,8 @@ class TestCommit(DockerTest):
         self.show_git_log()
 
         self.execute()
-        self.assert_text_in_logs(17, '    Co-authored-by: name3 <email3@localhost>')
-        self.assert_text_in_logs(18, '    Co-authored-by: name4 <email4@localhost>')
+        self.assert_text_in_logs(23, '    Co-authored-by: name3 <email3@localhost>')
+        self.assert_text_in_logs(24, '    Co-authored-by: name4 <email4@localhost>')
 
     def test_wont_allow_commit_if_guet_set_hasnt_been_done(self):
         self.guet_init()
@@ -88,7 +88,7 @@ class TestCommit(DockerTest):
 
         self.execute()
 
-        self.assert_text_in_logs(4, 'You must set your pairs before you can commit.')
+        self.assert_text_in_logs(7, 'You must set your pairs before you can commit.')
 
     def test_can_make_committs_in_multiple_repos_with_committers_set(self):
         self.guet_init()
@@ -112,8 +112,8 @@ class TestCommit(DockerTest):
 
         self.execute()
 
-        self.assert_text_in_logs(13, '    Co-authored-by: name <email@localhost>')
-        self.assert_text_in_logs(14, '    Co-authored-by: name2 <email2@localhost>')
+        self.assert_text_in_logs(19, '    Co-authored-by: name <email@localhost>')
+        self.assert_text_in_logs(20, '    Co-authored-by: name2 <email2@localhost>')
 
     def test_handles_old_version_of_committersset_string(self):
         self.guet_init()
@@ -130,5 +130,5 @@ class TestCommit(DockerTest):
 
         self.execute()
 
-        self.assert_text_in_logs(11, '    Co-authored-by: name <email@localhost>')
-        self.assert_text_in_logs(12, '    Co-authored-by: name2 <email2@localhost>')
+        self.assert_text_in_logs(14, '    Co-authored-by: name <email@localhost>')
+        self.assert_text_in_logs(15, '    Co-authored-by: name2 <email2@localhost>')

--- a/e2e/test_commit.py
+++ b/e2e/test_commit.py
@@ -16,8 +16,8 @@ class TestCommit(DockerTest):
 
         self.execute()
 
-        self.assert_text_in_logs(10, '    Co-authored-by: name <email@localhost>')
-        self.assert_text_in_logs(11, '    Co-authored-by: name2 <email2@localhost>')
+        self.assert_text_in_logs(11, '    Co-authored-by: name <email@localhost>')
+        self.assert_text_in_logs(12, '    Co-authored-by: name2 <email2@localhost>')
 
     def test_if_only_one_committer_set_no_co_authored_by_lines_are_added(self):
         self.guet_init()
@@ -31,7 +31,7 @@ class TestCommit(DockerTest):
         self.show_git_log()
 
         self.execute()
-        self.assertEqual(10, len(self.logs))
+        self.assertEqual(11, len(self.logs))
 
     def test_replaces_co_authored_messages_when_editing_commit(self):
         self.guet_init()
@@ -52,8 +52,8 @@ class TestCommit(DockerTest):
         self.show_git_log()
 
         self.execute()
-        self.assert_text_in_logs(16, '    Co-authored-by: name3 <email3@localhost>')
-        self.assert_text_in_logs(17, '    Co-authored-by: name4 <email4@localhost>')
+        self.assert_text_in_logs(17, '    Co-authored-by: name3 <email3@localhost>')
+        self.assert_text_in_logs(18, '    Co-authored-by: name4 <email4@localhost>')
 
     def test_wont_allow_commit_if_guet_set_hasnt_been_done(self):
         self.guet_init()
@@ -65,7 +65,7 @@ class TestCommit(DockerTest):
 
         self.execute()
 
-        self.assert_text_in_logs(1, 'You must set your pairs before you can commit.')
+        self.assert_text_in_logs(2, 'You must set your pairs before you can commit.')
 
     def test_wont_allow_commits_in_guet_repo_if_pairs_havent_been_set_in_that_repo(self):
         self.guet_init()
@@ -88,7 +88,7 @@ class TestCommit(DockerTest):
 
         self.execute()
 
-        self.assert_text_in_logs(2, 'You must set your pairs before you can commit.')
+        self.assert_text_in_logs(4, 'You must set your pairs before you can commit.')
 
     def test_can_make_committs_in_multiple_repos_with_committers_set(self):
         self.guet_init()
@@ -112,8 +112,8 @@ class TestCommit(DockerTest):
 
         self.execute()
 
-        self.assert_text_in_logs(11, '    Co-authored-by: name <email@localhost>')
-        self.assert_text_in_logs(12, '    Co-authored-by: name2 <email2@localhost>')
+        self.assert_text_in_logs(13, '    Co-authored-by: name <email@localhost>')
+        self.assert_text_in_logs(14, '    Co-authored-by: name2 <email2@localhost>')
 
     def test_handles_old_version_of_committersset_string(self):
         self.guet_init()
@@ -130,5 +130,5 @@ class TestCommit(DockerTest):
 
         self.execute()
 
-        self.assert_text_in_logs(10, '    Co-authored-by: name <email@localhost>')
-        self.assert_text_in_logs(11, '    Co-authored-by: name2 <email2@localhost>')
+        self.assert_text_in_logs(11, '    Co-authored-by: name <email@localhost>')
+        self.assert_text_in_logs(12, '    Co-authored-by: name2 <email2@localhost>')

--- a/e2e/test_commit_changes_current_author.py
+++ b/e2e/test_commit_changes_current_author.py
@@ -24,9 +24,9 @@ class TestGuetCommitRotatesAuthor(DockerTest):
 
         self.execute()
 
-        self.assert_text_in_logs(31, 'Author: {} <{}>'.format('name', 'email@localhost'))
-        self.assert_text_in_logs(21, 'Author: {} <{}>'.format('name2', 'email2@localhost'))
-        self.assert_text_in_logs(11, 'Author: {} <{}>'.format('name3', 'email3@localhost'))
+        self.assert_text_in_logs(32, 'Author: {} <{}>'.format('name', 'email@localhost'))
+        self.assert_text_in_logs(22, 'Author: {} <{}>'.format('name2', 'email2@localhost'))
+        self.assert_text_in_logs(12, 'Author: {} <{}>'.format('name3', 'email3@localhost'))
 
     def test_second_commit_uses_second_pair_name_and_email(self):
         self.guet_init()
@@ -45,4 +45,4 @@ class TestGuetCommitRotatesAuthor(DockerTest):
 
         self.execute()
 
-        self.assert_text_in_logs(8, 'Author: {} <{}>'.format('name2', 'email2@localhost'))
+        self.assert_text_in_logs(9, 'Author: {} <{}>'.format('name2', 'email2@localhost'))

--- a/e2e/test_commit_changes_current_author.py
+++ b/e2e/test_commit_changes_current_author.py
@@ -24,9 +24,9 @@ class TestGuetCommitRotatesAuthor(DockerTest):
 
         self.execute()
 
-        self.assert_text_in_logs(32, 'Author: {} <{}>'.format('name', 'email@localhost'))
-        self.assert_text_in_logs(22, 'Author: {} <{}>'.format('name2', 'email2@localhost'))
-        self.assert_text_in_logs(12, 'Author: {} <{}>'.format('name3', 'email3@localhost'))
+        self.assert_text_in_logs(36, 'Author: {} <{}>'.format('name', 'email@localhost'))
+        self.assert_text_in_logs(26, 'Author: {} <{}>'.format('name2', 'email2@localhost'))
+        self.assert_text_in_logs(16, 'Author: {} <{}>'.format('name3', 'email3@localhost'))
 
     def test_second_commit_uses_second_pair_name_and_email(self):
         self.guet_init()
@@ -45,4 +45,4 @@ class TestGuetCommitRotatesAuthor(DockerTest):
 
         self.execute()
 
-        self.assert_text_in_logs(9, 'Author: {} <{}>'.format('name2', 'email2@localhost'))
+        self.assert_text_in_logs(12, 'Author: {} <{}>'.format('name2', 'email2@localhost'))

--- a/e2e/test_get.py
+++ b/e2e/test_get.py
@@ -14,9 +14,9 @@ class TestGet(DockerTest):
 
         self.execute()
 
-        self.assert_text_in_logs(2, 'Currently set committers')
-        self.assert_text_in_logs(3, 'initials1 - name1 <email1>')
-        self.assert_text_in_logs(4, 'initials2 - name2 <email2>')
+        self.assert_text_in_logs(5, 'Currently set committers')
+        self.assert_text_in_logs(6, 'initials1 - name1 <email1>')
+        self.assert_text_in_logs(7, 'initials2 - name2 <email2>')
 
     def test_get_committers_prints_all_committers_on_the_system(self):
         self.guet_init()

--- a/e2e/test_get.py
+++ b/e2e/test_get.py
@@ -14,9 +14,9 @@ class TestGet(DockerTest):
 
         self.execute()
 
-        self.assert_text_in_logs(1, 'Currently set committers')
-        self.assert_text_in_logs(2, 'initials1 - name1 <email1>')
-        self.assert_text_in_logs(3, 'initials2 - name2 <email2>')
+        self.assert_text_in_logs(2, 'Currently set committers')
+        self.assert_text_in_logs(3, 'initials1 - name1 <email1>')
+        self.assert_text_in_logs(4, 'initials2 - name2 <email2>')
 
     def test_get_committers_prints_all_committers_on_the_system(self):
         self.guet_init()

--- a/e2e/test_setcommitter.py
+++ b/e2e/test_setcommitter.py
@@ -14,7 +14,7 @@ class TestGuetSet(DockerTest):
 
         self.execute()
 
-        self.assert_text_in_logs(1, "No committer exists with initials 'ui'")
+        self.assert_text_in_logs(2, "No committer exists with initials 'ui'")
 
     def test_adds_committer_initials_and_current_millis_to_committersset_file(self):
         start_time = int(round(time.time() * 1000))
@@ -48,9 +48,9 @@ class TestGuetSet(DockerTest):
 
         self.execute()
 
-        self.assert_text_in_logs(1, 'Currently set committers')
-        self.assert_text_in_logs(2, 'initials1 - name1 <email1>')
-        self.assert_text_in_logs(3, 'initials2 - name2 <email2>')
+        self.assert_text_in_logs(2, 'Currently set committers')
+        self.assert_text_in_logs(3, 'initials1 - name1 <email1>')
+        self.assert_text_in_logs(4, 'initials2 - name2 <email2>')
 
 
     def test_set_committer_required_init_to_have_ran_before_usage(self):
@@ -64,7 +64,7 @@ class TestGuetSet(DockerTest):
         self.guet_start()
         self.guet_set([])
         self.execute()
-        self.assert_text_in_logs(1, 'usage: guet set <initials> [<initials> ...]')
+        self.assert_text_in_logs(2, 'usage: guet set <initials> [<initials> ...]')
 
     def test_errors_if_guet_set_ran_in_folder_with_no_git(self):
         self.guet_init()
@@ -113,6 +113,6 @@ class TestGuetSet(DockerTest):
 
         self.execute()
 
-        self.assert_text_in_logs(1, 'Currently set committers')
-        self.assert_text_in_logs(2, 'initials1 - name1 <email1>')
-        self.assert_text_in_logs(3, 'initials2 - name2 <email2>')
+        self.assert_text_in_logs(3, 'Currently set committers')
+        self.assert_text_in_logs(4, 'initials1 - name1 <email1>')
+        self.assert_text_in_logs(5, 'initials2 - name2 <email2>')

--- a/e2e/test_setcommitter.py
+++ b/e2e/test_setcommitter.py
@@ -48,10 +48,9 @@ class TestGuetSet(DockerTest):
 
         self.execute()
 
-        self.assert_text_in_logs(2, 'Currently set committers')
-        self.assert_text_in_logs(3, 'initials1 - name1 <email1>')
-        self.assert_text_in_logs(4, 'initials2 - name2 <email2>')
-
+        self.assert_text_in_logs(5, 'Currently set committers')
+        self.assert_text_in_logs(6, 'initials1 - name1 <email1>')
+        self.assert_text_in_logs(7, 'initials2 - name2 <email2>')
 
     def test_set_committer_required_init_to_have_ran_before_usage(self):
         self.guet_set(['initials1'])
@@ -113,6 +112,6 @@ class TestGuetSet(DockerTest):
 
         self.execute()
 
-        self.assert_text_in_logs(3, 'Currently set committers')
-        self.assert_text_in_logs(4, 'initials1 - name1 <email1>')
-        self.assert_text_in_logs(5, 'initials2 - name2 <email2>')
+        self.assert_text_in_logs(6, 'Currently set committers')
+        self.assert_text_in_logs(7, 'initials1 - name1 <email1>')
+        self.assert_text_in_logs(8, 'initials2 - name2 <email2>')

--- a/e2e/test_start.py
+++ b/e2e/test_start.py
@@ -30,7 +30,11 @@ class TestStart(DockerTest):
         self.guet_start(overwrite_answer='x')
         self.execute()
         self.assert_text_in_logs(1,
-                                 'There is already commit hooks in this project. Would you like to overwrite (o), create (a) the file and put it in the hooks folder, or cancel (x)?')
+                                 'There is already commit hooks in this project. Would you like to')
+        self.assert_text_in_logs(2, '  (o) Overwrite current hooks. This will delete any matching hooks.')
+        self.assert_text_in_logs(3, ('  (a) Create guet hooks alongside current ones.'
+                                     'This will create them with \'-guet\' appended on the name of the hook file.'))
+        self.assert_text_in_logs(4, '  (x) Cancel the request. This will do nothing.')
 
     def test_passing_dash_a_to_command_creates_alongside_without_prompt(self):
         self.guet_init()

--- a/e2e/test_start.py
+++ b/e2e/test_start.py
@@ -10,6 +10,13 @@ class TestStart(DockerTest):
         self.execute()
         self.assert_file_exists('test-env/.git/hooks/commit-msg')
 
+    def test_tells_user_when_guet_has_successfully_started(self):
+        self.guet_init()
+        self.git_init()
+        self.guet_start()
+        self.execute()
+        self.assert_text_in_logs(1, 'guet successfully started in this repository.')
+
     def test_tells_user_that_a_git_folder_does_not_exist(self):
         self.guet_init()
         self.guet_start()

--- a/e2e/test_start.py
+++ b/e2e/test_start.py
@@ -30,11 +30,11 @@ class TestStart(DockerTest):
         self.guet_start(overwrite_answer='x')
         self.execute()
         self.assert_text_in_logs(1,
-                                 'There is already commit hooks in this project. Would you like to')
-        self.assert_text_in_logs(2, '  (o) Overwrite current hooks. This will delete any matching hooks.')
-        self.assert_text_in_logs(3, ('  (a) Create guet hooks alongside current ones.'
+                                 'There is already commit hooks in this project. You can')
+        self.assert_text_in_logs(2, '  (o) overwrite current hooks. This will delete any matching hooks.')
+        self.assert_text_in_logs(3, ('  (a) create guet hooks alongside current ones.'
                                      'This will create them with \'-guet\' appended on the name of the hook file.'))
-        self.assert_text_in_logs(4, '  (x) Cancel the request. This will do nothing.')
+        self.assert_text_in_logs(4, '  (x) cancel the request. This will do nothing.')
 
     def test_passing_dash_a_to_command_creates_alongside_without_prompt(self):
         self.guet_init()

--- a/guet/commands/usercommands/get/committer_printing_strategy.py
+++ b/guet/commands/usercommands/get/committer_printing_strategy.py
@@ -1,6 +1,7 @@
 from typing import List, Callable
 
 from guet.commands.strategies.strategy import CommandStrategy
+from guet.committers import CommittersPrinter
 from guet.committers.committer import Committer
 
 
@@ -8,11 +9,11 @@ class CommitterPrintingStrategy(CommandStrategy):
     def __init__(self,
                  committers: List[Committer],
                  pre_print_strategy: Callable[[], None],
-                 listing_strategy: Callable[[List[Committer]], None]):
+                 committers_printer: CommittersPrinter):
         self.committers = committers
         self.pre_print_strategy = pre_print_strategy
-        self.listing_strategy = listing_strategy
+        self.committers_printer = committers_printer
 
     def apply(self):
         self.pre_print_strategy()
-        self.listing_strategy(self.committers)
+        self.committers_printer.print(self.committers)

--- a/guet/commands/usercommands/get/get_factory.py
+++ b/guet/commands/usercommands/get/get_factory.py
@@ -7,18 +7,9 @@ from guet.commands.strategies.strategy import CommandStrategy
 from guet.commands.strategies.strategy_command import StrategyCommand
 from guet.commands.usercommands.help.help_message_builder import HelpMessageBuilder, FlagBuilder, FlagsBuilder
 from guet.commands.usercommands.usercommand_factory import UserCommandFactory
+from guet.committers import CommittersPrinter
 from guet.committers.committer import Committer
 from guet.settings.settings import Settings
-
-
-def print_full_names(committers: List[Committer]) -> None:
-    for committer in committers:
-        print(committer.pretty())
-
-
-def print_only_initials(committers: List[Committer]) -> None:
-    print(', '.join([committer.initials for committer in committers]))
-
 
 GET_HELP_MESSAGE = HelpMessageBuilder('guet get <identifier> [-flag, ...]', 'Get currently set information.') \
     .explanation(('Valid Identifier'
@@ -49,6 +40,6 @@ class GetCommandFactory(UserCommandFactory):
         identifier = args[1]
         committers, pre_print = self._determine_identifier(identifier)
         if '-l' in args:
-            return CommitterPrintingStrategy(committers, lambda: None, print_only_initials)
+            return CommitterPrintingStrategy(committers, lambda: None, CommittersPrinter(initials_only=True))
         else:
-            return CommitterPrintingStrategy(committers, pre_print, print_full_names)
+            return CommitterPrintingStrategy(committers, pre_print, CommittersPrinter(initials_only=False))

--- a/guet/commands/usercommands/get/get_factory.py
+++ b/guet/commands/usercommands/get/get_factory.py
@@ -8,7 +8,6 @@ from guet.commands.strategies.strategy_command import StrategyCommand
 from guet.commands.usercommands.help.help_message_builder import HelpMessageBuilder, FlagBuilder, FlagsBuilder
 from guet.commands.usercommands.usercommand_factory import UserCommandFactory
 from guet.committers import CommittersPrinter
-from guet.committers.committer import Committer
 from guet.settings.settings import Settings
 
 GET_HELP_MESSAGE = HelpMessageBuilder('guet get <identifier> [-flag, ...]', 'Get currently set information.') \

--- a/guet/commands/usercommands/setcommitters/set_committers_strategy.py
+++ b/guet/commands/usercommands/setcommitters/set_committers_strategy.py
@@ -1,6 +1,7 @@
 from typing import List
 
 from guet.commands.strategies.strategy import CommandStrategy
+from guet.committers import CommittersPrinter
 from guet.committers.committer import filter_committers_with_initials, Committer
 from guet.context.context import Context
 
@@ -24,6 +25,9 @@ class SetCommittersStrategy(CommandStrategy):
                     print(f"No committer exists with initials '{initials}'")
         else:
             self.context.set_committers(committers_to_set)
+            print('Committers set to:')
+            committers_printer = CommittersPrinter(initials_only=False)
+            committers_printer.print(committers_to_set)
 
     def _committer_with_initials_present(self, committers: List[Committer], initials: str):
         committer_with_initial_present = False

--- a/guet/commands/usercommands/start/create_alongside_hook_strategy.py
+++ b/guet/commands/usercommands/start/create_alongside_hook_strategy.py
@@ -2,5 +2,5 @@ from guet.commands.usercommands.start.hook_strategy import HookStrategy
 
 
 class CreateAlongsideHookStrategy(HookStrategy):
-    def apply(self):
+    def _hook_apply(self) -> None:
         self.git.create_hooks(alongside=True)

--- a/guet/commands/usercommands/start/create_hook_strategy.py
+++ b/guet/commands/usercommands/start/create_hook_strategy.py
@@ -2,5 +2,5 @@ from guet.commands.usercommands.start.hook_strategy import HookStrategy
 
 
 class CreateHookStrategy(HookStrategy):
-    def apply(self):
+    def _hook_apply(self) -> None:
         self.git.create_hooks()

--- a/guet/commands/usercommands/start/hook_strategy.py
+++ b/guet/commands/usercommands/start/hook_strategy.py
@@ -8,4 +8,8 @@ class HookStrategy(CommandStrategy):
         self.git = git
 
     def apply(self):
+        self._hook_apply()
+        print('guet successfully started in this repository.')
+
+    def _hook_apply(self) -> None:
         raise NotImplementedError

--- a/guet/commands/usercommands/start/start_strategy.py
+++ b/guet/commands/usercommands/start/start_strategy.py
@@ -5,7 +5,7 @@ from guet.commands.usercommands.start.hook_strategy import HookStrategy
 
 
 class PromptUserForHookTypeStrategy(HookStrategy):
-    def apply(self):
+    def _hook_apply(self) -> None:
         print('There is already commit hooks in this project. You can')
         print('  (o) overwrite current hooks. This will delete any matching hooks.')
         print(('  (a) create guet hooks alongside current ones.'

--- a/guet/commands/usercommands/start/start_strategy.py
+++ b/guet/commands/usercommands/start/start_strategy.py
@@ -6,9 +6,11 @@ from guet.commands.usercommands.start.hook_strategy import HookStrategy
 
 class PromptUserForHookTypeStrategy(HookStrategy):
     def apply(self):
-        print(('There is already commit hooks in this project. ' +
-               'Would you like to overwrite (o), ' +
-               'create (a) the file and put it in the hooks folder, or cancel (x)?'))
+        print('There is already commit hooks in this project. You can')
+        print('  (o) overwrite current hooks. This will delete any matching hooks.')
+        print(('  (a) create guet hooks alongside current ones.'
+               'This will create them with \'-guet\' appended on the name of the hook file.'))
+        print('  (x) cancel the request. This will do nothing.')
         val = input()
         if val == 'o':
             CreateHookStrategy(self.git).apply()

--- a/guet/committers/__init__.py
+++ b/guet/committers/__init__.py
@@ -1,0 +1,1 @@
+from guet.committers._comitters_printer import CommittersPrinter

--- a/guet/committers/_comitters_printer.py
+++ b/guet/committers/_comitters_printer.py
@@ -1,0 +1,21 @@
+from typing import List
+
+from guet.committers.committer import Committer
+
+
+class CommittersPrinter:
+    def __init__(self, *, initials_only: bool):
+        self.initials_only = initials_only
+
+    def print(self, committers: List[Committer]):
+        if self.initials_only:
+            self._initials_print(committers)
+        else:
+            self._pretty_print(committers)
+
+    def _initials_print(self, committers: List[Committer]):
+        print(', '.join([committer.initials for committer in committers]))
+
+    def _pretty_print(self, committers: List[Committer]):
+        for committer in committers:
+            print(committer.pretty())

--- a/test/commands/usercommands/setcommitters/test_set_committers_strategy.py
+++ b/test/commands/usercommands/setcommitters/test_set_committers_strategy.py
@@ -21,6 +21,39 @@ class TestSetCommittersStrategy(TestCase):
 
         mock_context.set_committers.assert_called_with([committer1, committer2])
 
+    @patch('guet.commands.usercommands.setcommitters.set_committers_strategy.CommittersPrinter')
+    @patch('builtins.print')
+    def test_apply_set_commiters_with_context(self, mock_print, mock_committers_printer):
+        mock_context = Mock()
+        mock_committers = Mock()
+        mock_context.committers = mock_committers
+        committer1 = Committer(name='name1', email='email1', initials='initials1')
+        committer2 = Committer(name='name2', email='email2', initials='initials2')
+        mock_committers.all.return_value = [committer1, committer2]
+
+        strategy = SetCommittersStrategy(['initials1', 'initials2'], mock_context)
+        strategy.apply()
+
+        mock_print.assert_called_with('Committers set to:')
+        mock_committers_printer.return_value.print.assert_called_with([committer1, committer2])
+
+    @patch('guet.commands.usercommands.setcommitters.set_committers_strategy.CommittersPrinter')
+    @patch('builtins.print')
+    def test_apply_only_prints_names_of_set_committers(self, mock_print, mock_committers_printer):
+        mock_context = Mock()
+        mock_committers = Mock()
+        mock_context.committers = mock_committers
+        committer1 = Committer(name='name1', email='email1', initials='initials1')
+        committer2 = Committer(name='name2', email='email2', initials='initials2')
+        committer3 = Committer(name='name3', email='email3', initials='initials3')
+        mock_committers.all.return_value = [committer1, committer2, committer3]
+
+        strategy = SetCommittersStrategy(['initials1', 'initials2'], mock_context)
+        strategy.apply()
+
+        mock_print.assert_called_with('Committers set to:')
+        mock_committers_printer.return_value.print.assert_called_with([committer1, committer2])
+
     @patch('builtins.print')
     def test_execute_prints_out_error_message_when_the_given_initials_arent_in_the_system(self, mock_print):
         mock_context = Mock()

--- a/test/committers/test_committers_printer.py
+++ b/test/committers/test_committers_printer.py
@@ -1,0 +1,30 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+from guet.committers import CommittersPrinter
+from guet.committers.committer import Committer
+
+
+@patch('builtins.print')
+class TestCommittersPrinter(TestCase):
+
+    def test_pretty_prints_committer_names(self, mock_print):
+        committers = [
+            Committer(name='Name1', initials='initials1', email='email1'),
+            Committer(name='Name2', initials='initials2', email='email2')
+        ]
+        committers_printer = CommittersPrinter(initials_only=False)
+        committers_printer.print(committers)
+
+        mock_print.assert_any_call(committers[0].pretty())
+        mock_print.assert_any_call(committers[1].pretty())
+
+    def test_prints_committer_initials_only(self, mock_print):
+        committers = [
+            Committer(name='Name1', initials='initials1', email='email1'),
+            Committer(name='Name2', initials='initials2', email='email2')
+        ]
+        committers_printer = CommittersPrinter(initials_only=True)
+        committers_printer.print(committers)
+
+        mock_print.assert_any_call('initials1, initials2')

--- a/test/context/test_context.py
+++ b/test/context/test_context.py
@@ -32,6 +32,19 @@ class TestContext(TestCase):
 
         observer.notify_of_committer_set.assert_called_with([committer1, committer2])
 
+    def test_set_committers_prints_names_of_committers_on_success(self, mock_git, mock_committers):
+        context = Context(Path('current/working/directory'))
+
+        committer1 = Committer(name='name1', email='email1', initials='initials1')
+        committer2 = Committer(name='name2', email='email2', initials='initials2')
+
+        observer: SetCommitterObserver = Mock()
+        context.add_set_committer_observer(observer)
+
+        context.set_committers([committer1, committer2])
+
+        observer.notify_of_committer_set.assert_called_with([committer1, committer2])
+
     def test_set_committers_raises_exception_when_given_an_empty_list(self, mock_git, mock_committers):
         context = Context(Path('current/working/directory/'))
 


### PR DESCRIPTION
## Overview
Adds better success messages in the following instances:
- When user sets committers (in which case it prints the names of the set committers)
- When user starts guet tracking on a repository

Also adds a more detailed prompt for when a user guet starts in a repository that has commit hooks already.