### PR TITLE
Create hooks folder when one is not present

### DIFF
--- a/e2e/test_start.py
+++ b/e2e/test_start.py
@@ -85,3 +85,12 @@ class TestStart(DockerTest):
         self.assertEqual('#! /usr/bin/env python3', self.get_file_text('test-env/.git/hooks/post-commit')[0])
         self.assertEqual('#! /usr/bin/env python3', self.get_file_text('test-env/.git/hooks/commit-msg')[0])
         self.assertEqual('#! /usr/bin/env python3', self.get_file_text('test-env/.git/hooks/pre-commit')[0])
+
+    def test_attempting_to_start_in_project_without_hooks_creates_hooks_folder(self):
+        self.guet_init()
+        self.git_init()
+        self.add_command('rm -rf .git/hooks')
+        self.guet_start()
+        self.execute()
+
+        self.assert_text_in_logs(1, 'No hooks directory found, creating one.')

--- a/guet/git/_hook_loader.py
+++ b/guet/git/_hook_loader.py
@@ -11,10 +11,16 @@ class HookLoader:
     def __init__(self, path_to_repository: Path, file_name: FileNameStrategy, create: CreateStrategy):
         self.create = create
         self.file_name = file_name
-        self.path_to_repository = path_to_repository
+        self._hooks_directory: Path = path_to_repository.joinpath('hooks')
+
+    def _create_hooks_directory_if_not_present(self):
+        if not self._hooks_directory.is_dir():
+            self._hooks_directory.mkdir()
+            print('No hooks directory found, creating one.')
 
     def apply(self, hook_name: str, hooks: List[Hook]):
-        hook_path = self.path_to_repository.joinpath('hooks').joinpath(self.file_name.apply(hook_name))
+        self._create_hooks_directory_if_not_present()
+        hook_path = self._hooks_directory.joinpath(self.file_name.apply(hook_name))
         try:
             hooks.append(Hook(hook_path, create=self.create.apply()))
         except FileNotFoundError:

--- a/test/git/test_git.py
+++ b/test/git/test_git.py
@@ -255,6 +255,24 @@ class TestGit(TestCase):
         post_commit_hook.save.assert_called()
         commit_msg_hook.save.assert_called()
 
+    def test_create_hooks_adds_hook_folder_if_it_doesnt_exist(self, mock_hook, _1):
+        hooks_directory = self.path_to_git.joinpath.return_value
+        hooks_directory.is_dir.return_value = False
+        git = Git(self.path_to_git)
+        git.hooks = []
+
+        mock_hook.reset_mock()
+        pre_commit_hook = Mock()
+        post_commit_hook = Mock()
+        commit_msg_hook = Mock()
+        expected_hooks = [pre_commit_hook, post_commit_hook, commit_msg_hook]
+        mock_hook.side_effect = expected_hooks
+
+        git.create_hooks()
+
+        self.path_to_git.joinpath.assert_called_with('hooks')
+        hooks_directory.mkdir.assert_called()
+
     @patch('guet.git.git.write_lines')
     def test_notify_of_author_sets_the_author_proprty(self, mock_write_lines, _1, _2):
         git = Git(self.path_to_git)


### PR DESCRIPTION
## Overview
Create hooks folder when it isn't already present.

Connects #80

### Demo
```
$ rm -rf .git/hooks
$ guet start
No hooks directory found, creating one. 
guet successfully started in this repository.
```