### PR TITLE
Update FAQ to cover using husky in monorepos

### DIFF
--- a/.github/FAQ.md
+++ b/.github/FAQ.md
@@ -13,6 +13,12 @@ To use guet with husky, you will need to start guet tracking alongside any prese
   }
 ```
 
+If package.json is not in the root of the repository you'll have to change to the root directory before each guet hook:
+```json
+  "pre-commit": "yarn test && cd .. && .git/hooks/pre-commit-guet"
+```
+This will not work: `"post-commit": "../.git/hooks/pre-commit-guet"`
+
 ### I want to squash my commit, but still save co-authors. What do I do?
 
 As long as your your `Co-authored-by Name <emai>` lines are in the squashed commit, they will show up. In this example, you can remove all the duplicated lines under the "File 2" commit.


### PR DESCRIPTION
## Overview
I'm using guet and husky in a monorepo, and it took me a bit of troubleshooting to get it working. I'm hoping some additional examples in the FAQ might save someone the same effort.

## Background
Husky runs scripts in the same directory as package.json, so it can't find the .git folder to run guet hooks. However, if I try something like  this: `"post-commit": "../.git/hooks/pre-commit-guet"`  then one of the committers is the author and other committers are ignored. There is no error message.

I thought about making a feature request like _Support running guet from directories below repository root when guet is installed alongside other hooks_. But I think adding a couple examples to the readme is sufficient to enable people who want to script guet from outside of the root directory.

### Demo
With the following file structure, set up husky. Follow the FAQ on using husky with guet. The co-authors should be set correctly.
```
/
  .git/
    hooks/
      pre-commit-guet
      pre-commit
      etc.
  web/
    package.json
  api/
```


### Notes
current FAQ example
```json
  "husky": {
    "hooks": {
      "pre-commit": "lint-staged && .git/hooks/pre-commit-guet",
      "commit-msg": ".git/hooks/commit-msg-guet",
      "post-commit": ".git/hooks/post-commit-guet"
    }
  },
```
My first attempt that failed
```json
  "husky": {
    "hooks": {
      "pre-commit": "lint-staged && ../.git/hooks/pre-commit-guet",
      "commit-msg": "../.git/hooks/commit-msg-guet",
      "post-commit": "../.git/hooks/post-commit-guet"
    }
  },
```
Working solution
```json
  "husky": {
    "hooks": {
      "pre-commit": "lint-staged && cd .. && .git/hooks/pre-commit-guet",
      "commit-msg": "cd .. && .git/hooks/commit-msg-guet",
      "post-commit": "cd .. && .git/hooks/post-commit-guet"
    }
  },
```
