### PR TITLE
Add guet yeet command

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,22 @@ repos:
     hooks:
     - id: isort
       args: [--check-only]
+      always_run: true
+      files: \.(py)$
+      entry: isort ./guet/**/*.py --check-only
+      pass_filenames: false
+    - id: isort
+      args: [--check-only]
+      always_run: true
+      files: \.(py)$
+      entry: isort ./e2e/**/*.py --check-only
+      pass_filenames: false
+    - id: isort
+      args: [--check-only]
+      always_run: true
+      files: \.(py)$
+      entry: isort ./test/**/*.py --check-only
+      pass_filenames: false
   - repo: local
     hooks:
     -   id: unit-tests
@@ -17,6 +33,7 @@ repos:
         language: system
         types: [python]
         always_run: true
+        pass_filenames: false
   - repo: local
     hooks:
     -   id: e2e-tests
@@ -26,3 +43,4 @@ repos:
         types: [python]
         always_run: true
         stages: [push]
+        pass_filenames: false

--- a/e2e/dockertest/file_system.py
+++ b/e2e/dockertest/file_system.py
@@ -18,6 +18,7 @@ class FileSystem:
         for file in self.files:
             if file.path == path:
                 return file
+        return None
 
     def get_file_from_root(self, path: str) -> DockerFile:
         return self.get_file(f'/root/{path}')

--- a/e2e/test_add_local.py
+++ b/e2e/test_add_local.py
@@ -1,3 +1,5 @@
+# pylint: disable=line-too-long
+
 from e2e import DockerTest
 
 

--- a/e2e/test_get.py
+++ b/e2e/test_get.py
@@ -30,7 +30,7 @@ class TestGet(DockerTest):
         self.assert_text_in_logs(2, 'initials2 - name2 <email2>')
 
     def test_prints_help_message(self):
-        self.guet_get_committers(help=True)
+        self.guet_get_committers(include_help=True)
         self.execute()
         self.assert_text_in_logs(0, 'usage: guet get <identifier> [-flag, ...]')
         self.assert_text_in_logs(2, 'Get currently set information.')

--- a/e2e/test_init.py
+++ b/e2e/test_init.py
@@ -1,3 +1,5 @@
+# pylint: disable=line-too-long
+
 from e2e import DockerTest
 from guet.steps.check.git_required_check import GIT_REQUIRED_MESSAGE
 

--- a/e2e/test_setcommitter.py
+++ b/e2e/test_setcommitter.py
@@ -1,3 +1,5 @@
+# pylint: disable=line-too-long
+
 import time
 
 from e2e import DockerTest

--- a/e2e/test_yeet.py
+++ b/e2e/test_yeet.py
@@ -11,7 +11,6 @@ class TestYeet(DockerTest):
         self.execute()
         self.assert_text_in_logs(2, 'guet tracking removed from this repository')
 
-
     def test_commit_doesnt_have_co_authored_because_hooks_removed(self):
         self.git_init()
         self.guet_init()

--- a/e2e/test_yeet.py
+++ b/e2e/test_yeet.py
@@ -1,0 +1,12 @@
+from e2e import DockerTest
+
+
+class TestYeet(DockerTest):
+
+    def test_yeets_guet_from_repository(self):
+        self.git_init()
+        self.guet_init()
+        self.guet_add('initials', 'name', 'email', local=True)
+        self.guet_yeet()
+        self.execute()
+        self.assert_text_in_logs(2, 'guet tracking removed from this repository')

--- a/e2e/test_yeet.py
+++ b/e2e/test_yeet.py
@@ -10,3 +10,31 @@ class TestYeet(DockerTest):
         self.guet_yeet()
         self.execute()
         self.assert_text_in_logs(2, 'guet tracking removed from this repository')
+
+
+    def test_commit_doesnt_have_co_authored_because_hooks_removed(self):
+        self.git_init()
+        self.guet_init()
+        self.guet_add('initials', 'name', 'email@localhost')
+        self.guet_add('initials2', 'name2', 'email2@localhost')
+        self.guet_set(['initials', 'initials2'])
+        self.add_file('A')
+        self.guet_yeet()
+        self.git_add()
+        self.git_commit('Initial commit')
+        self.show_git_log()
+
+        self.execute()
+
+        self.assert_text_in_logs(12, '')
+        self.assert_text_in_logs(13, '    Initial commit')
+        self.assert_text_in_logs(14, '')
+
+    def test_yeet_doesnt_remove_non_guet_hooks(self):
+        self.git_init()
+        self.add_file('.git/hooks/commit-msg')
+        self.guet_init(overwrite_answer='a')
+        self.guet_yeet()
+        self.save_file_content('test-env/.git/hooks/commit-msg')
+        self.execute()
+        self.assert_file_exists('test-env/.git/hooks/commit-msg')

--- a/guet/commands/yeet/__init__.py
+++ b/guet/commands/yeet/__init__.py
@@ -1,0 +1,1 @@
+from ._yeet import YeetCommandFactory

--- a/guet/commands/yeet/_remove_global.py
+++ b/guet/commands/yeet/_remove_global.py
@@ -8,7 +8,7 @@ from guet.steps.action import Action
 
 class RemoveGlobal(Action):
     def execute(self, args: List[str]):
-        if any(arg in ('-f', '--force') for arg in args):
+        if any(arg in ('-g', '--global') for arg in args):
             configuration_dir = Path(CONFIGURATION_DIRECTORY)
             rmtree(configuration_dir)
             print('Bye!')

--- a/guet/commands/yeet/_remove_global.py
+++ b/guet/commands/yeet/_remove_global.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+from shutil import rmtree
+from typing import List
+
+from guet.config import CONFIGURATION_DIRECTORY
+from guet.steps.action import Action
+
+
+class RemoveGlobal(Action):
+    def execute(self, args: List[str]):
+        if any(arg in ('-f', '--force') for arg in args):
+            configuration_dir = Path(CONFIGURATION_DIRECTORY)
+            rmtree(configuration_dir)
+            print('Bye!')

--- a/guet/commands/yeet/_remove_local.py
+++ b/guet/commands/yeet/_remove_local.py
@@ -1,0 +1,15 @@
+from os.path import isdir
+from shutil import rmtree
+from typing import List
+
+from guet.steps.action import Action
+from guet.util import project_root
+
+
+class RemoveLocal(Action):
+    def execute(self, args: List[str]):
+        if isdir(project_root().joinpath('.guet')):
+            rmtree(project_root().joinpath('.guet'))
+            print('guet tracking removed from this repository')
+        else:
+            print('No local guet configurations for this project')

--- a/guet/commands/yeet/_remove_local.py
+++ b/guet/commands/yeet/_remove_local.py
@@ -2,12 +2,21 @@ from os.path import isdir
 from shutil import rmtree
 from typing import List
 
+from guet.files import FileSystem
+from guet.git import Git, all_guet_hooks
 from guet.steps.action import Action
 from guet.util import project_root
 
 
 class RemoveLocal(Action):
+    def __init__(self, git: Git, file_system: FileSystem):
+        super().__init__()
+        self.git = git
+        self.file_system = file_system
+
     def execute(self, args: List[str]):
+        for hook in all_guet_hooks(self.file_system):
+            hook.delete()
         if isdir(project_root().joinpath('.guet')):
             rmtree(project_root().joinpath('.guet'))
             print('guet tracking removed from this repository')

--- a/guet/commands/yeet/_yeet.py
+++ b/guet/commands/yeet/_yeet.py
@@ -24,5 +24,5 @@ class YeetCommandFactory(CommandFactory):
             .next(HelpCheck('temp')) \
             .next(InitializePreparation(self.file_system)) \
             .next(GitRequiredCheck(self.git)) \
-            .next(RemoveLocal()) \
+            .next(RemoveLocal(self.git, self.file_system)) \
             .next(RemoveGlobal())

--- a/guet/commands/yeet/_yeet.py
+++ b/guet/commands/yeet/_yeet.py
@@ -7,6 +7,7 @@ from guet.steps import Step
 from guet.steps.check import GitRequiredCheck, HelpCheck, VersionCheck
 from guet.steps.preparation import InitializePreparation
 
+from ._remove_global import RemoveGlobal
 from ._remove_local import RemoveLocal
 
 
@@ -23,4 +24,5 @@ class YeetCommandFactory(CommandFactory):
             .next(HelpCheck('temp')) \
             .next(InitializePreparation(self.file_system)) \
             .next(GitRequiredCheck(self.git)) \
-            .next(RemoveLocal())
+            .next(RemoveLocal()) \
+            .next(RemoveGlobal())

--- a/guet/commands/yeet/_yeet.py
+++ b/guet/commands/yeet/_yeet.py
@@ -1,0 +1,26 @@
+from typing import List
+
+from guet.commands import CommandFactory
+from guet.files import FileSystem
+from guet.git import Git
+from guet.steps import Step
+from guet.steps.check import GitRequiredCheck, HelpCheck, VersionCheck
+from guet.steps.preparation import InitializePreparation
+
+from ._remove_local import RemoveLocal
+
+
+class YeetCommandFactory(CommandFactory):
+    def __init__(self, file_system: FileSystem, git: Git):
+        self.file_system = file_system
+        self.git = git
+
+    def choose(self, args: List[str]):
+        return 1 if '--local' in args else 0
+
+    def build(self) -> Step:
+        return VersionCheck() \
+            .next(HelpCheck('temp')) \
+            .next(InitializePreparation(self.file_system)) \
+            .next(GitRequiredCheck(self.git)) \
+            .next(RemoveLocal())

--- a/guet/files/_file.py
+++ b/guet/files/_file.py
@@ -1,3 +1,4 @@
+from os import remove
 from pathlib import Path
 from typing import Callable, List
 
@@ -9,6 +10,8 @@ class File:
     def __init__(self, absolute_path: Path):
         self._content = None
         self._absolute_path = absolute_path
+        self._marked_for_deletion = False
+        self._written_to = False
 
     def read(self) -> List[str]:
         try:
@@ -18,13 +21,20 @@ class File:
         return self._content
 
     def write(self, new_content: List[str]):
+        self._written_to = True
         self._content = new_content
+        self._marked_for_deletion = False
 
     def save(self):
-        if self._content is not None:
+        if self._marked_for_deletion:
+            remove(self._absolute_path)
+        elif self._content is not None and self._written_to:
             write_lines(self._absolute_path, self._content)
 
     def overwrite(self, matcher: Callable[[str], bool], new_line: str):
         for index, line in enumerate(self.read()):
             if matcher(line):
                 self._content[index] = new_line
+
+    def delete(self):
+        self._marked_for_deletion = True

--- a/guet/git/__init__.py
+++ b/guet/git/__init__.py
@@ -1,2 +1,3 @@
+from ._all_guet_hooks import all_guet_hooks
 from ._git_proxy import GitProxy
 from .git import Git

--- a/guet/git/_all_guet_hooks.py
+++ b/guet/git/_all_guet_hooks.py
@@ -1,0 +1,29 @@
+from typing import List
+
+from guet.files import File, FileSystem
+from guet.util import project_root
+
+from .hook import shared_hook_lines
+
+_FILE_NAMES = [
+    'pre-commit',
+    'post-commit',
+    'commit-msg',
+    'pre-commit-guet',
+    'post-commit-guet',
+    'commit-msg-guet',
+]
+
+def _is_guet_file(content: List[str]) -> bool:
+    return content[1:] == shared_hook_lines()
+
+
+def all_guet_hooks(file_system: FileSystem) -> List[File]:
+    git_hooks_path = project_root().joinpath('.git').joinpath('hooks')
+    found = []
+    for file_name in _FILE_NAMES:
+        file = file_system.get(git_hooks_path.joinpath(file_name))
+        if _is_guet_file(file.read()):
+            found.append(file)
+
+    return found

--- a/guet/git/_all_valid_hooks.py
+++ b/guet/git/_all_valid_hooks.py
@@ -24,12 +24,19 @@ def _dash_guet_normal_hooks(hooks: List[Hook]) -> List[Hook]:
 
 
 def all_valid_hooks(hooks: List[Hook]) -> bool:
+    return len(valid_hooks(hooks)) > 0
+
+
+def valid_hooks(hooks: List[Hook]) -> List[Hook]:
     hook_names = [_name(hook) for hook in _normal_hooks(hooks)]
     valid_names = GUET_HOOKS == hook_names
     valid_content = all([hook.is_guet_hook() for hook in _normal_hooks(hooks)])
+    if (valid_names and valid_content):
+        return [hook for hook in hooks if _name(hook).replace('-guet', '') in hook_names]
     if not (valid_names and valid_content):
         hook_names = [_name(hook).replace('-guet', '') for hook in _dash_guet_normal_hooks(hooks)]
         valid_names = GUET_HOOKS == hook_names
         valid_content = all([hook.is_guet_hook() for hook in _dash_guet_normal_hooks(hooks)])
-        return valid_names and valid_content
-    return True
+        if valid_names and valid_content:
+            return [hook for hook in hooks if _name(hook).replace('-guet', '') in hook_names]
+    return []

--- a/guet/git/git.py
+++ b/guet/git/git.py
@@ -5,7 +5,7 @@ from guet.committers import CurrentCommittersObserver
 from guet.committers.committer import Committer
 from guet.files.read_lines import read_lines
 from guet.files.write_lines import write_lines
-from guet.git._all_valid_hooks import all_valid_hooks
+from guet.git._all_valid_hooks import all_valid_hooks, valid_hooks
 from guet.git._author_manage import (append_new_author, get_author_lines,
                                      load_author, overwrite_current_author)
 from guet.git._create_strategy import DoCreateStrategy, DontCreateStrategy
@@ -92,6 +92,9 @@ class Git(CurrentCommittersObserver):
         self.hooks = _load_hooks(hook_loader)
         for hook in self.hooks:
             hook.save()
+
+    def guet_hooks(self) -> List[str]:
+        return [hook.path for hook in valid_hooks(self.hooks)]
 
     def on_new_committers(self, committers: List[Committer]):
         author_committer = committers[0]

--- a/guet/git/hook.py
+++ b/guet/git/hook.py
@@ -7,7 +7,7 @@ from guet.files.read_lines import read_lines
 from guet.files.write_lines import write_lines
 
 
-def _shared_hook_lines() -> List[str]:
+def shared_hook_lines() -> List[str]:
     return [
         'from guet.hooks import run',
         'import sys',
@@ -15,12 +15,13 @@ def _shared_hook_lines() -> List[str]:
     ]
 
 
-PYTHON_GUET_HOOK = ['#! /usr/bin/env python'] + _shared_hook_lines()
+PYTHON_GUET_HOOK = ['#! /usr/bin/env python'] + shared_hook_lines()
 
-PYTHON3_GUET_HOOK = ['#! /usr/bin/env python3'] + _shared_hook_lines()
+PYTHON3_GUET_HOOK = ['#! /usr/bin/env python3'] + shared_hook_lines()
 
 
 class Hook:
+
     def __init__(self, path_to_hook: Path, *, create: bool = False):
         self.path = path_to_hook
         self.content = self._parse_file_content(create, path_to_hook)

--- a/guet/hooks/_run.py
+++ b/guet/hooks/_run.py
@@ -22,6 +22,7 @@ def run(hook: str):
     command = _choose_command(hook)
     if command:
         command.play([])
+    FILE_SYSTEM.save_all()
 
 
 def _choose_command(hook: str) -> Union[Step, None]:

--- a/guet/main.py
+++ b/guet/main.py
@@ -46,3 +46,5 @@ def main():
 
     command = command_map.get_command(args[0]).build()
     command.play(args[1:])
+
+    file_system.save_all()

--- a/guet/main.py
+++ b/guet/main.py
@@ -7,6 +7,7 @@ from guet.commands.help import HelpCommandFactory, UnknownCommandFactory
 from guet.commands.init import InitCommandFactory
 from guet.commands.remove import RemoveCommandFactory
 from guet.commands.set import SetCommittersCommand
+from guet.commands.yeet import YeetCommandFactory
 from guet.committers import Committers2, CurrentCommitters
 from guet.files import FileSystem
 from guet.git import GitProxy
@@ -35,6 +36,9 @@ def main():
         file_system, committers, current_committers, git), 'Set committers for current repository')
     command_map.add_command('remove', RemoveCommandFactory(
         file_system, committers), 'Remove committer')
+    command_map.add_command('yeet',
+                            YeetCommandFactory(file_system, git),
+                            'Remove guet configurations')
 
     command_map.set_default(UnknownCommandFactory(command_map))
 

--- a/guet/steps/preparation/initialize.py
+++ b/guet/steps/preparation/initialize.py
@@ -33,7 +33,7 @@ class InitializePreparation(Preparation):
 
     def _create_empty_file(self, path: Path) -> None:
         file = self._file_system.get(path)
-        file.read()
+        file.write([])
         return file
 
     def _create_configuration_folder(self) -> None:

--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,12 @@ from setuptools import setup
 import guet
 
 with open("README.md", "r") as fh:
-    long_description = fh.read()
+    LONG_DESCRIPTION = fh.read()
 
 setup(name='guet',
       version=guet.__version__,
       description='Enable contribution tracking when pair programming',
-      long_description=long_description,
+      long_description=LONG_DESCRIPTION,
       long_description_content_type="text/markdown",
       url='https://github.com/chiptopher/guet',
       keywords='pair programming',
@@ -22,6 +22,7 @@ setup(name='guet',
           'guet.commands.init',
           'guet.commands.remove',
           'guet.commands.set',
+          'guet.commands.yeet',
           'guet.committers',
           'guet.config',
           'guet.files',

--- a/test/commands/yeet/test_remove_global.py
+++ b/test/commands/yeet/test_remove_global.py
@@ -11,14 +11,14 @@ from guet.config import CONFIGURATION_DIRECTORY
 class TestRemoveGlobal(TestCase):
     def test_removes_guet_directory_with_dash_f(self, mock_rmtree, mock_print):
         remove_global = RemoveGlobal()
-        remove_global.execute(['-f'])
+        remove_global.execute(['-g'])
 
         mock_rmtree.assert_called_with(Path(CONFIGURATION_DIRECTORY))
         mock_print.assert_called_with('Bye!')
 
     def test_removes_guet_directory_with_force(self, mock_rmtree, mock_print):
         remove_global = RemoveGlobal()
-        remove_global.execute(['--force'])
+        remove_global.execute(['--global'])
 
         mock_rmtree.assert_called_with(Path(CONFIGURATION_DIRECTORY))
         mock_print.assert_called_with('Bye!')

--- a/test/commands/yeet/test_remove_global.py
+++ b/test/commands/yeet/test_remove_global.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+from unittest import TestCase
+from unittest.mock import patch
+
+from guet.commands.yeet._remove_global import RemoveGlobal
+from guet.config import CONFIGURATION_DIRECTORY
+
+
+@patch('builtins.print')
+@patch('guet.commands.yeet._remove_global.rmtree')
+class TestRemoveGlobal(TestCase):
+    def test_removes_guet_directory_with_dash_f(self, mock_rmtree, mock_print):
+        remove_global = RemoveGlobal()
+        remove_global.execute(['-f'])
+
+        mock_rmtree.assert_called_with(Path(CONFIGURATION_DIRECTORY))
+        mock_print.assert_called_with('Bye!')
+
+    def test_removes_guet_directory_with_force(self, mock_rmtree, mock_print):
+        remove_global = RemoveGlobal()
+        remove_global.execute(['--force'])
+
+        mock_rmtree.assert_called_with(Path(CONFIGURATION_DIRECTORY))
+        mock_print.assert_called_with('Bye!')
+
+    def test_doesnt_remove_without_force(self, mock_rmtree, mock_print):
+        remove_global = RemoveGlobal()
+        remove_global.execute(['--other'])
+
+        mock_rmtree.assert_not_called()
+        mock_print.assert_not_called()

--- a/test/commands/yeet/test_remove_local.py
+++ b/test/commands/yeet/test_remove_local.py
@@ -1,24 +1,34 @@
 from pathlib import Path
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from guet.commands.yeet._remove_local import RemoveLocal
 
 
+@patch('guet.commands.yeet._remove_local.all_guet_hooks', return_value=[])
 @patch('builtins.print')
 @patch('guet.commands.yeet._remove_local.isdir', return_value=True)
 @patch('guet.commands.yeet._remove_local.project_root', return_value=Path('path/to/root'))
 @patch('guet.commands.yeet._remove_local.rmtree')
 class TestRemoveLocal(TestCase):
-    def test_removes_local_guet_directory(self, mockrmtree, mock_root, _1, _2,):
-        remove_local = RemoveLocal()
+    def test_removes_local_guet_directory(self, mockrmtree, mock_root, _1, _2, _3):
+        mock_git = Mock()
+        mock_git.guet_hooks.return_value = []
+        remove_local = RemoveLocal(mock_git, Mock())
         remove_local.execute([])
 
         mockrmtree.assert_called_with(mock_root.return_value.joinpath('.guet'))
 
-    def test_prints_error_message_when_no_guet_present(self, mockrmtree, _, mock_isdir, mock_print):
+    def test_prints_error_message_when_no_guet_present(self,
+                                                       mockrmtree,
+                                                       _,
+                                                       mock_isdir,
+                                                       mock_print,
+                                                       _2):
+        mock_git = Mock()
+        mock_git.guet_hooks.return_value = []
         mock_isdir.return_value = False
-        remove_local = RemoveLocal()
+        remove_local = RemoveLocal(mock_git, Mock())
         remove_local.execute([])
 
         mockrmtree.assert_not_called()

--- a/test/commands/yeet/test_remove_local.py
+++ b/test/commands/yeet/test_remove_local.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+from unittest import TestCase
+from unittest.mock import patch
+
+from guet.commands.yeet._remove_local import RemoveLocal
+
+
+@patch('builtins.print')
+@patch('guet.commands.yeet._remove_local.isdir', return_value=True)
+@patch('guet.commands.yeet._remove_local.project_root', return_value=Path('path/to/root'))
+@patch('guet.commands.yeet._remove_local.rmtree')
+class TestRemoveLocal(TestCase):
+    def test_removes_local_guet_directory(self, mockrmtree, mock_root, _1, _2,):
+        remove_local = RemoveLocal()
+        remove_local.execute([])
+
+        mockrmtree.assert_called_with(mock_root.return_value.joinpath('.guet'))
+
+    def test_prints_error_message_when_no_guet_present(self, mockrmtree, _, mock_isdir, mock_print):
+        mock_isdir.return_value = False
+        remove_local = RemoveLocal()
+        remove_local.execute([])
+
+        mockrmtree.assert_not_called()
+        mock_print.assert_called_with('No local guet configurations for this project')

--- a/test/git/test_all_guet_hooks.py
+++ b/test/git/test_all_guet_hooks.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+from unittest import TestCase
+from unittest.mock import Mock, call, patch
+
+from guet.git._all_guet_hooks import all_guet_hooks
+
+
+@patch('guet.git._all_guet_hooks.project_root', return_value=Path('project/root'))
+class TestAllGuetHooks(TestCase):
+
+    def test_loads_all_expected_hooks(self, mock_project_root):
+        mock_file = Mock()
+        mock_file.read.return_value = []
+
+        file_system = Mock()
+        file_system.get.return_value = mock_file
+
+        all_guet_hooks(file_system)
+
+        hooks_path = mock_project_root.return_value.joinpath('.git').joinpath('hooks')
+
+        file_system.get.assert_has_calls([
+            call(hooks_path.joinpath('pre-commit')),
+            call().read(),
+            call(hooks_path.joinpath('post-commit')),
+            call().read(),
+            call(hooks_path.joinpath('commit-msg')),
+            call().read(),
+            call(hooks_path.joinpath('pre-commit-guet')),
+            call().read(),
+            call(hooks_path.joinpath('post-commit-guet')),
+            call().read(),
+            call(hooks_path.joinpath('commit-msg-guet')),
+            call().read(),
+        ])
+
+    def test_only_returns_files_with_guet_content(self, _1):
+        mock_with = Mock()
+        mock_with.read.return_value = [
+            '#! /usr/bin/env python3',
+            'from guet.hooks import run',
+            'import sys',
+            'run(sys.argv[0])',
+        ]
+        mock_without = Mock()
+        mock_without.read.return_value = [
+            'some',
+            'other',
+            'lines',
+        ]
+
+        file_system = Mock()
+        file_system.get.side_effect = [
+            mock_with,
+            mock_without,
+            mock_with,
+            mock_without,
+            mock_with,
+            mock_without,
+        ]
+
+        result = all_guet_hooks(file_system)
+
+        self.assertEqual([mock_with, mock_with, mock_with], result)

--- a/test/step/preparation/test_initialize.py
+++ b/test/step/preparation/test_initialize.py
@@ -12,7 +12,9 @@ from guet.steps.preparation.initialize import InitializePreparation
 @patch('guet.steps.preparation.initialize.isdir')
 class TestInitializePreparation(unittest.TestCase):
 
-    def test_prepare_creates_initialization_folders_and_files(self, mock_isdir, mock_mkdir):
+    def test_prepare_creates_initialization_folders_and_files(self,
+                                                              mock_isdir,
+                                                              _1):
         mock_isdir.return_value = False
         config_dir = Path(CONFIGURATION_DIRECTORY)
         mock_filesystem: FileSystem = Mock()
@@ -21,31 +23,31 @@ class TestInitializePreparation(unittest.TestCase):
 
         mock_filesystem.get.assert_has_calls([
             call(Path(config_dir.joinpath(constants.COMMITTER_NAMES))),
-            call().read(),
+            call().write([]),
             call(Path(config_dir.joinpath(constants.CONFIG))),
-            call().read(),
+            call().write([]),
             call(Path(config_dir.joinpath(constants.COMMITTERS))),
-            call().read(),
+            call().write([]),
             call(Path(config_dir.joinpath(constants.COMMITTERS_SET))),
-            call().read(),
+            call().write([]),
             call(Path(config_dir.joinpath(constants.ERRORS))),
-            call().read(),
+            call().write([]),
         ])
 
         mock_filesystem.save_all.assert_called()
 
     def test_prepare_creates_initialization_directory(self, mock_isdir, mock_mkdir):
         mock_isdir.return_value = False
-        config_dir = Path(CONFIGURATION_DIRECTORY)
         mock_filesystem: FileSystem = Mock()
         preparation_step = InitializePreparation(mock_filesystem)
         preparation_step.prepare([])
 
         mock_mkdir.assert_called_with(CONFIGURATION_DIRECTORY)
 
-    def test_prepare_doesnt_create_initialization_directory_if_already_present(self, mock_isdir, mock_mkdir):
+    def test_prepare_doesnt_create_initialization_directory_if_already_present(self,
+                                                                               mock_isdir,
+                                                                               mock_mkdir):
         mock_isdir.return_value = True
-        config_dir = Path(CONFIGURATION_DIRECTORY)
         mock_filesystem: FileSystem = Mock()
         preparation_step = InitializePreparation(mock_filesystem)
         preparation_step.prepare([])


### PR DESCRIPTION
## Overview
Introduces a `guet yeet` command for the version 3.0 release which removes related guet files.

Connects #95 

### Demo
```
$ guet init
$ ls .git/hooks
commit-msg pre-commit post-commit
$ guet yeet
$ ls .git/hooks

```


### Notes
Also introduces a couple extra `isort` checks